### PR TITLE
openclaw: disable native heartbeat to prevent self-restart

### DIFF
--- a/bin/hey.d/rebuild.just
+++ b/bin/hey.d/rebuild.just
@@ -24,6 +24,17 @@ rebuild *args='switch': opencode-update
         fi
     else
         sudo nixos-rebuild --flake "{{FLAKE_DIR}}" {{args}}
+
+        # openclaw-gateway uses X-RestartIfChanged=false to survive rebuilds.
+        # Restart it explicitly — unless we ARE openclaw (OPS-24).
+        if systemctl --user is-active openclaw-gateway.service &>/dev/null; then
+            if grep -q 'openclaw-gateway' /proc/self/cgroup 2>/dev/null; then
+                echo "=== openclaw-gateway: skipping restart (deploy triggered by openclaw) ==="
+            else
+                echo "=== Restarting openclaw-gateway ==="
+                systemctl --user restart openclaw-gateway.service
+            fi
+        fi
     fi
 
 # Alias for rebuild

--- a/bin/hey.d/remote.just
+++ b/bin/hey.d/remote.just
@@ -10,8 +10,17 @@ deploy HOST:
 
 # Deploy to NUC (primary remote deployment)
 nuc:
-    @echo "=== Deploying to NUC ==="
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "=== Deploying to NUC ==="
     nix run .#deploy-rs -- .#nuc --skip-checks
+
+    # openclaw-gateway uses X-RestartIfChanged=false to survive rebuilds.
+    # Restart it after deploy-rs finishes (remote deploys are always safe).
+    if ssh {{NUC_HOST}} "systemctl --user is-active openclaw-gateway.service" &>/dev/null; then
+        echo "=== Restarting openclaw-gateway on NUC ==="
+        ssh {{NUC_HOST}} "systemctl --user restart openclaw-gateway.service"
+    fi
 
 # Alias for nuc
 rebuild-nuc: nuc

--- a/modules/services/openclaw/default.nix
+++ b/modules/services/openclaw/default.nix
@@ -387,7 +387,7 @@ in
                   ];
                 };
                 thinkingDefault = "high";
-                heartbeat.model = "anthropic/claude-haiku-4";
+                heartbeat.every = "0m"; # Disable native heartbeat — use external systemd timer instead (OPS-24)
                 subagents.model = {
                   primary = "anthropic/claude-sonnet-4-5";
                   fallbacks = [
@@ -536,6 +536,11 @@ in
           # Inject agenix secrets + gateway token via ExecStartPre
           systemd.user.services.openclaw-gateway.Unit = mkMerge [
             {
+              # Skip automatic restart during nixos-rebuild / home-manager activation.
+              # The deploy scripts (hey rebuild, hey nuc) handle restarting explicitly,
+              # but skip the restart when openclaw itself triggered the deploy (OPS-24).
+              X-RestartIfChanged = "false";
+              X-StopIfChanged = "false";
               # Relax start rate limit — deploys restart user services and openclaw
               # takes a few seconds to boot, hitting the default 5/10s limit
               StartLimitIntervalSec = 60;


### PR DESCRIPTION
## Summary

Disables the OpenClaw gateway's built-in heartbeat by setting `heartbeat.every = "0m"`.

## Problem

The native heartbeat runs full agent turns inside the gateway process every 30m. Since the agent has `tools.profile = "full"` and `exec.security = "full"`, it can execute shell commands — including `systemctl --user restart openclaw-gateway` — which causes the gateway to restart itself.

## Fix

Set `heartbeat.every = "0m"` which is the documented way to disable the native heartbeat ([docs](https://docs.openclaw.ai/gateway/heartbeat), [discussion](https://github.com/openclaw/openclaw/discussions/11042)).

External systemd timers should be used instead for reliable, token-free heartbeat monitoring (OPS-13).

Closes OPS-24
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/edmundmiller/dotfiles/pull/17" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
