### PR TITLE
feat(homebox): pin package to 0.26.2

### DIFF
--- a/modules/services/homebox/_tests/eval-homebox.nix
+++ b/modules/services/homebox/_tests/eval-homebox.nix
@@ -29,8 +29,8 @@ let
       msg = "Homebox must be enabled on the NUC";
     }
     {
-      test = (homebox.package.version or "") == "0.25.0";
-      msg = "Homebox must use pinned package version 0.25.0";
+      test = (homebox.package.version or "") == "0.26.2";
+      msg = "Homebox must use pinned package version 0.26.2";
     }
     {
       test = (settings.HBOX_WEB_HOST or "") == "127.0.0.1";

--- a/modules/services/homebox/default.nix
+++ b/modules/services/homebox/default.nix
@@ -9,6 +9,37 @@ with lib;
 with lib.my;
 let
   cfg = config.modules.services.homebox;
+  homeboxPackage = pkgs.homebox.overrideAttrs (
+    old:
+    let
+      version = "0.26.2";
+      src = pkgs.fetchFromGitHub {
+        owner = "sysadminsmedia";
+        repo = "homebox";
+        tag = "v${version}";
+        hash = "sha256-JUhRpUWbydy28Xw7j6oCKJLBmaOxcruWAdkqm+hvouY=";
+      };
+    in
+    {
+      inherit version src;
+      vendorHash = "sha256-peQaPSbxGn8MnbZPqCi5ptW+dMh9l4W1hB6HqBLTqh4=";
+      pnpmDeps = pkgs.fetchPnpmDeps {
+        inherit (old) pname;
+        inherit version;
+        src = "${src}/frontend";
+        pnpm = pkgs.pnpm_10;
+        fetcherVersion = 3;
+        hash = "sha256-oHS2uMWyuqpiK7yWznmZ2mgxPJpWsyOZL2wz6zBu0cc=";
+      };
+      ldflags = [
+        "-s"
+        "-w"
+        "-extldflags=-static"
+        "-X main.version=v${version}"
+        "-X main.commit=v${version}"
+      ];
+    }
+  );
 in
 {
   options.modules.services.homebox = {
@@ -33,6 +64,7 @@ in
 
       services.homebox = {
         enable = true;
+        package = homeboxPackage;
         settings = {
           HBOX_WEB_HOST = "127.0.0.1";
           HBOX_WEB_PORT = "7745";


### PR DESCRIPTION
## Summary
- Module-local pin of Homebox to **0.26.2** (src/vendorHash/pnpmDeps/ldflags)
- Eval assertion updated so the pin cannot silently regress to nixpkgs 0.25.0

## Why
NUC production already runs **v0.26.2** with a migrated entity-merge DB. Without this pin, the next normal deploy from main would rebuild 0.25.0 against that DB.

## Verification
- Live NUC: `build.version=v0.26.2`, health true, registration false, HTTPS 200, register 403
- Pilot data intact: 15 Box 5 items, 11 locations
- R2 restic snapshot `11198e87` (tag `homebox-state`) includes `homebox.db`
- Local rollback copy: `/var/lib/homebox-upgrade-backup-20260718T135417Z`
- Clean deploy from `origin/main` + this pin (no stale-base override)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/edmundmiller/dotfiles/pull/165" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->