### PR TITLE
feat(ast-grep): require module eval tests under _tests/

### DIFF
--- a/ast-grep/rule-tests/module-eval-tests-location-test.yml
+++ b/ast-grep/rule-tests/module-eval-tests-location-test.yml
@@ -1,0 +1,17 @@
+id: module-eval-tests-location
+valid:
+  # Non-assertion filters and ordinary module runCommands stay quiet.
+  - "filter (x: x > 0) numbers"
+  - "builtins.filter (x: x != null) items"
+  - 'pkgs.runCommand "build-asset" { } "touch $out"'
+  - "config.systemd.services.foo.serviceConfig.ExecStart"
+invalid:
+  # Canonical eval-assertion failure fold.
+  - "filter (a: !a.test) assertions"
+  - "filter (assertion: !assertion.test) assertions"
+  - "builtins.filter (assertion: !assertion.test) assertions"
+  # Multi-line / richer predicates still count as the eval-test shape.
+  - |
+    filter (
+      a: (!a.test && !(a.expectedFailure or false)) || (a.test && (a.expectedFailure or false))
+    ) assertions

--- a/ast-grep/rules/module-eval-tests-location.yml
+++ b/ast-grep/rules/module-eval-tests-location.yml
@@ -1,0 +1,14 @@
+id: module-eval-tests-location
+language: nix
+severity: error
+files:
+  - modules/**/*.nix
+ignores:
+  # mapModules/mapModulesRec skip any directory whose name starts with _
+  - "**/_*/**"
+message: Put module eval assertion checks under _tests/ so mapModules skips them.
+note: mapModules and mapModulesRec skip directories prefixed with _. A sibling eval-*.nix or tests/default.nix under a mapped module path is auto-imported as a NixOS module. Keep pure eval assertion helpers in modules/<path>/_tests/ (for example eval-homebox.nix) and wire them from flake checks.
+rule:
+  any:
+    - pattern: "filter ($A: $$$BODY) assertions"
+    - pattern: "builtins.filter ($A: $$$BODY) assertions"


### PR DESCRIPTION
## Summary
- Add `module-eval-tests-location` ast-grep rule: flag `filter (... ) assertions` / `builtins.filter (... ) assertions` under `modules/**` outside private `**/_*/**` trees (same skip contract as `mapModules`).
- Preferred location remains `modules/<path>/_tests/`; wire from flake checks.

## Test plan
- [x] `ast-grep test --skip-snapshot-tests`
- [x] `ast-grep scan` clean on tree
- [x] Path smoke: non-`_` path flagged; `_tests` and `_domains` ignored