### PR TITLE
fix(ast-grep): ignore underscore-private module files

### DIFF
--- a/ast-grep/rules/module-eval-tests-location.yml
+++ b/ast-grep/rules/module-eval-tests-location.yml
@@ -4,10 +4,11 @@ severity: error
 files:
   - modules/**/*.nix
 ignores:
-  # mapModules/mapModulesRec skip any directory whose name starts with _
+  # mapModules/mapModulesRec skip any entry whose name starts with _
   - "**/_*/**"
+  - "**/_*.nix"
 message: Put module eval assertion checks under _tests/ so mapModules skips them.
-note: mapModules and mapModulesRec skip directories prefixed with _. A sibling eval-*.nix or tests/default.nix under a mapped module path is auto-imported as a NixOS module. Keep pure eval assertion helpers in modules/<path>/_tests/ (for example eval-homebox.nix) and wire them from flake checks.
+note: mapModules and mapModulesRec skip names prefixed with _ (dirs and files). A sibling eval-*.nix or tests/default.nix under a mapped module path is auto-imported as a NixOS module. Keep pure eval assertion helpers in modules/<path>/_tests/ (for example eval-homebox.nix) and wire them from flake checks.
 rule:
   any:
     - pattern: "filter ($A: $$$BODY) assertions"


### PR DESCRIPTION
## Summary
- Extend `module-eval-tests-location` ignores with `**/_*.nix`.
- Matches `mapModules` which skips **all** `_`-prefixed entry names, not only directories.

## Test plan
- [x] `ast-grep test --skip-snapshot-tests`
- [x] `ast-grep scan` clean
- [x] Path smoke: `eval-bad.nix` flagged; `_eval.nix`, `_tests/`, `_domains/` ignored
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/edmundmiller/dotfiles/pull/167" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->