### PR TITLE
feat(skills): add Herdr voice dispatcher

### DIFF
--- a/skills/catalog/herdr-voice-dispatcher/SKILL.md
+++ b/skills/catalog/herdr-voice-dispatcher/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: herdr-voice-dispatcher
+description: Dispatches spoken or written prompts to live Herdr agents and reports their status or results. Use when the user says to list, check, ask, tell, prompt, steer, or wait for an OMP, Codex, or other agent running in Herdr.
+---
+
+# Herdr voice dispatcher
+
+Translate conversational requests into bounded Herdr CLI actions. This skill is
+an external controller for Codex Voice or chat, so it intentionally works
+without `HERDR_ENV=1`.
+
+## Connect
+
+1. Run the concise inventory without native session references:
+
+   ```bash
+   python3 ~/.agents/skills/herdr-voice-dispatcher/scripts/list_agents.py
+   ```
+
+2. If Herdr is unavailable, report the exact error.
+   - For `Operation not permitted`, ask the user to run the Codex task with
+     Full Access; a skill cannot bypass the sandbox.
+3. Do not dump raw `herdr agent list` output. It includes noisy native session
+   references.
+
+## Resolve the target
+
+- Use an exact live agent name or pane ID.
+- If the user names a project, title, or directory, filter the inventory:
+
+  ```bash
+  python3 ~/.agents/skills/herdr-voice-dispatcher/scripts/list_agents.py --query dotfiles
+  ```
+
+- Treat labels such as `omp` or `codex` as agent kinds, not unique targets,
+  when several matches exist.
+- If more than one candidate remains, ask one concise clarification. Never
+  guess a pane.
+
+## Act
+
+**List or check status:** use the inventory helper. Use `herdr agent get
+"$target"` only when more detail about one resolved agent is necessary.
+
+**Dispatch work:** preserve the user's requested outcome and constraints, then
+submit without waiting:
+
+```bash
+herdr agent prompt "$target" "$prompt"
+```
+
+Report only that Herdr accepted the prompt. If the target was already
+`working`, explain that Herdr lifecycle state does not correlate completion to
+an individual queued turn.
+
+**Read a result:** check status, then read bounded output:
+
+```bash
+herdr agent read "$target" --source recent-unwrapped --lines 80
+```
+
+If recent output is incomplete because the agent uses an alternate screen, use
+`--source visible`. Do not claim success from `unknown` state or truncated
+output.
+
+**Wait when explicitly requested:** keep Voice responsive with a bounded wait:
+
+```bash
+herdr agent wait "$target" \
+  --until idle --until done --until blocked \
+  --timeout 60000
+```
+
+If the agent becomes `blocked`, read and relay its question. Do not answer it
+for the user.
+
+## Guardrails
+
+1. Prompt only the target and intent the user authorized.
+2. Never start, stop, focus, interrupt, send keys, or answer an approval unless
+   the user explicitly requests that exact action.
+3. Treat dispatch as an external state change; a zero exit status proves
+   submission, not task completion.
+4. Do not expose agent session paths or unrelated terminal content.
+5. Never wait indefinitely. Return control after 60 seconds and offer a fresh
+   status check.
+
+## Spoken examples
+
+- “Which Herdr agents need attention?” → list and summarize `blocked`,
+  `working`, and `done`.
+- “Tell the dotfiles reviewer to inspect the current diff without editing.” →
+  resolve one target, dispatch once, and return immediately.
+- “What did the reviewer say?” → check its state, then read bounded output.
+- “The reviewer is blocked—what does it need?” → read and relay the question
+  without answering it.

--- a/skills/catalog/herdr-voice-dispatcher/agents/openai.yaml
+++ b/skills/catalog/herdr-voice-dispatcher/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Herdr Voice Dispatcher"
+  short_description: "Dispatch voice prompts to Herdr agents"
+  default_prompt: "Use $herdr-voice-dispatcher to list my Herdr agents and send a prompt to the one I name."

--- a/skills/catalog/herdr-voice-dispatcher/scripts/list_agents.py
+++ b/skills/catalog/herdr-voice-dispatcher/scripts/list_agents.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Print a concise, session-secret-free Herdr agent inventory."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from typing import Any
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="List live Herdr agents without native session references."
+    )
+    parser.add_argument(
+        "--query",
+        help="Case-insensitive filter over pane, agent, status, cwd, and title.",
+    )
+    return parser.parse_args()
+
+
+def load_agents() -> list[dict[str, Any]]:
+    try:
+        result = subprocess.run(
+            ["herdr", "agent", "list"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        raise SystemExit("Error: herdr is not installed or is not on PATH.") from None
+
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "unknown error"
+        raise SystemExit(f"Error: herdr agent list failed: {detail}")
+
+    try:
+        payload = json.loads(result.stdout)
+        agents = payload["result"]["agents"]
+    except (json.JSONDecodeError, KeyError, TypeError) as error:
+        raise SystemExit(f"Error: unexpected Herdr response: {error}") from error
+
+    if not isinstance(agents, list):
+        raise SystemExit("Error: unexpected Herdr response: agents is not a list.")
+    return agents
+
+
+def summarize(agent: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "pane_id": agent.get("pane_id"),
+        "agent": agent.get("agent"),
+        "status": agent.get("agent_status"),
+        "cwd": agent.get("foreground_cwd") or agent.get("cwd"),
+        "title": agent.get("terminal_title_stripped")
+        or agent.get("terminal_title"),
+        "focused": bool(agent.get("focused")),
+    }
+
+
+def matches(agent: dict[str, Any], query: str) -> bool:
+    needle = query.casefold()
+    return any(needle in str(value).casefold() for value in agent.values())
+
+
+def main() -> int:
+    args = parse_args()
+    agents = [summarize(agent) for agent in load_agents()]
+
+    if args.query:
+        agents = [agent for agent in agents if matches(agent, args.query)]
+        if not agents:
+            print(
+                json.dumps(
+                    {"error": "no matching live Herdr agents", "query": args.query}
+                )
+            )
+            return 1
+
+    print(json.dumps({"agents": agents}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/catalog/herdr-voice-dispatcher/scripts/list_agents.py
+++ b/skills/catalog/herdr-voice-dispatcher/scripts/list_agents.py
@@ -61,7 +61,11 @@ def summarize(agent: dict[str, Any]) -> dict[str, Any]:
 
 def matches(agent: dict[str, Any], query: str) -> bool:
     needle = query.casefold()
-    return any(needle in str(value).casefold() for value in agent.values())
+    fields = ("pane_id", "agent", "status", "cwd", "title")
+    return any(
+        needle in str(agent.get(field)).casefold()
+        for field in fields
+    )
 
 
 def main() -> int:

--- a/tests/test_herdr_voice_dispatcher.py
+++ b/tests/test_herdr_voice_dispatcher.py
@@ -1,0 +1,78 @@
+import importlib.util
+import subprocess
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT = (
+    Path(__file__).parents[1]
+    / "skills/catalog/herdr-voice-dispatcher/scripts/list_agents.py"
+)
+SPEC = importlib.util.spec_from_file_location("herdr_voice_list_agents", SCRIPT)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class HerdrVoiceDispatcherTests(unittest.TestCase):
+    def test_summary_excludes_native_session_reference(self) -> None:
+        summary = MODULE.summarize(
+            {
+                "pane_id": "w1:p2",
+                "agent": "reviewer",
+                "agent_status": "working",
+                "cwd": "/repo",
+                "foreground_cwd": "/repo/worktree",
+                "terminal_title": "Review diff",
+                "focused": True,
+                "agent_session": {"value": "/private/session.jsonl"},
+            }
+        )
+
+        self.assertEqual(
+            summary,
+            {
+                "pane_id": "w1:p2",
+                "agent": "reviewer",
+                "status": "working",
+                "cwd": "/repo/worktree",
+                "title": "Review diff",
+                "focused": True,
+            },
+        )
+        self.assertNotIn("agent_session", summary)
+
+    def test_load_agents_reports_herdr_failure(self) -> None:
+        completed = subprocess.CompletedProcess(
+            ["herdr", "agent", "list"],
+            returncode=1,
+            stdout="",
+            stderr="Operation not permitted",
+        )
+
+        with patch.object(MODULE.subprocess, "run", return_value=completed):
+            with self.assertRaisesRegex(
+                SystemExit,
+                "herdr agent list failed: Operation not permitted",
+            ):
+                MODULE.load_agents()
+
+    def test_query_matches_project_title_or_pane(self) -> None:
+        agent = {
+            "pane_id": "w17:p1P",
+            "agent": "omp",
+            "status": "working",
+            "cwd": "/Users/example/.config/dotfiles",
+            "title": "Review skill",
+            "focused": False,
+        }
+
+        self.assertTrue(MODULE.matches(agent, "dotfiles"))
+        self.assertTrue(MODULE.matches(agent, "REVIEW"))
+        self.assertTrue(MODULE.matches(agent, "w17:p1p"))
+        self.assertFalse(MODULE.matches(agent, "mill-docs"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_herdr_voice_dispatcher.py
+++ b/tests/test_herdr_voice_dispatcher.py
@@ -73,6 +73,19 @@ class HerdrVoiceDispatcherTests(unittest.TestCase):
         self.assertTrue(MODULE.matches(agent, "w17:p1p"))
         self.assertFalse(MODULE.matches(agent, "mill-docs"))
 
+    @unittest.expectedFailure
+    def test_query_ignores_focus_state(self) -> None:
+        agent = {
+            "pane_id": "w1:p2",
+            "agent": "omp",
+            "status": "idle",
+            "cwd": "/repo",
+            "title": "Review skill",
+            "focused": False,
+        }
+
+        self.assertFalse(MODULE.matches(agent, "false"))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_herdr_voice_dispatcher.py
+++ b/tests/test_herdr_voice_dispatcher.py
@@ -73,7 +73,6 @@ class HerdrVoiceDispatcherTests(unittest.TestCase):
         self.assertTrue(MODULE.matches(agent, "w17:p1p"))
         self.assertFalse(MODULE.matches(agent, "mill-docs"))
 
-    @unittest.expectedFailure
     def test_query_ignores_focus_state(self) -> None:
         agent = {
             "pane_id": "w1:p2",


### PR DESCRIPTION
## Summary
- add a Codex Voice/chat skill for resolving and prompting live Herdr agents
- add a bounded inventory helper that omits native session references
- guard approvals, interrupts, ambiguous targets, and indefinite waits

## Verification
- `python3 -m unittest tests.test_herdr_voice_dispatcher`
- `quick_validate.py skills/catalog/herdr-voice-dispatcher`
- `nix flake check path:./skills`
- `hey check`
- live read-only Herdr inventory and fresh-agent forward test

## Deployment
Merge, then run `hey rebuild` from a clean current dotfiles checkout.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/edmundmiller/dotfiles/pull/187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->