### PR TITLE
feat(nuc): hand Buzz ownership to Flue 2 worker

### DIFF
--- a/.agents/worklogs/buzz-flue2-cutover.md
+++ b/.agents/worklogs/buzz-flue2-cutover.md
@@ -1,0 +1,41 @@
+# Worklog: buzz-flue2-cutover
+
+Status: blocked
+
+## Objective
+
+Move MillDocs Buzz ownership from the NUC direct responder and beta Flue Worker to a dedicated Flue 2 Worker while retaining the existing NUC Linear coding queue. Stop after source, deployment, and one fresh end-to-end Buzz verification agree.
+
+## Decisions
+
+- MillDocs owns the standalone Worker; dotfiles owns only NUC service and callback wiring.
+- Disable `buzz-mill-docs-codex.service`; keep `mill-docs-coding-agent.timer`.
+- Rehydrate conversation context from verified relay events instead of beta Durable Object state.
+- Use a cutover watermark plus an app-owned event-claim Durable Object; Flue 2.0.0 does not expose submission idempotency keys.
+
+## Evidence
+
+- Initial checkout clean on `codex/feedback-fix-loop`.
+- Host: `MacTraitor-Pro.local`, Darwin arm64; NUC checks and deployment must run through `hey nuc-wt` / `hey nuc`.
+- `uvx pytest -q tests/test_mill_docs_coding_agent.py`: 5 passed.
+- `hey nuc-wt build`: built `/nix/store/bsza5vfzr9y72d3x1j44q5kg0xzjisgq-nixos-system-nuc-26.11.20260714.18b9261`.
+- `hey agent-audit-tests ...`: `PASS test-confidence`.
+
+## Reviews
+
+- Plan: Claude review failed authentication; required Gemini retry also failed authentication. Implementation proceeded from the accepted user plan and local evidence.
+- Landing: Claude review failed authentication; required Gemini retry also failed authentication. Independent standards/spec reviews reached fixed point with no actionable findings.
+
+## Feedback
+
+None.
+
+## Remaining work
+
+- Clean or explicitly preserve the dirty MillDocs `main` checkout so the feature commit can land without touching unrelated vault edits.
+- After landing: deploy old-ownership removal, deploy NUC wiring, set the exact cutover watermark, enable the new poller, update the hosted Buzz workflow, and run live normal/fix acceptance.
+
+## Commits
+
+- `8a97feb47` — NUC Buzz ownership and callback wiring.
+- MillDocs companion commit: `520bb21`.

--- a/.agents/worklogs/buzz-flue2-cutover.md
+++ b/.agents/worklogs/buzz-flue2-cutover.md
@@ -37,5 +37,5 @@ None.
 
 ## Commits
 
-- `8a97feb47` — NUC Buzz ownership and callback wiring.
+- `834701648` — NUC Buzz ownership and callback wiring.
 - MillDocs companion commit: `520bb21`.

--- a/.agents/worklogs/buzz-flue2-cutover.md
+++ b/.agents/worklogs/buzz-flue2-cutover.md
@@ -20,6 +20,7 @@ Move MillDocs Buzz ownership from the NUC direct responder and beta Flue Worker 
 - `uvx pytest -q tests/test_mill_docs_coding_agent.py`: 5 passed.
 - `hey nuc-wt build`: built `/nix/store/bsza5vfzr9y72d3x1j44q5kg0xzjisgq-nixos-system-nuc-26.11.20260714.18b9261`.
 - `hey agent-audit-tests ...`: `PASS test-confidence`.
+- Standby Worker `2b5a87d4-a871-4598-9679-1c15ceba796e` is live with polling disabled; health is `200`, unauthenticated admin/callback access is rejected, and the NUC-held callback secret authenticates successfully.
 
 ## Reviews
 
@@ -33,9 +34,10 @@ None.
 ## Remaining work
 
 - Clean or explicitly preserve the dirty MillDocs `main` checkout so the feature commit can land without touching unrelated vault edits.
+- Repair or explicitly authorize the unrelated baseline CI failures: MillDocs board-meeting fixture/grocery-cron assertions and dotfiles repository formatting/statix debt.
 - After landing: deploy old-ownership removal, deploy NUC wiring, set the exact cutover watermark, enable the new poller, update the hosted Buzz workflow, and run live normal/fix acceptance.
 
 ## Commits
 
 - `834701648` — NUC Buzz ownership and callback wiring.
-- MillDocs companion commit: `520bb21`.
+- MillDocs companion commit: `7d9df00`.

--- a/docs/adr/0009-defer-buzz-self-hosting.md
+++ b/docs/adr/0009-defer-buzz-self-hosting.md
@@ -1,7 +1,7 @@
 ---
 purpose: Record why Buzz relay self-hosting remains deferred and bound the hosted NUC runtimes.
 applies_to: Decisions about self-hosting Buzz or operating NUC Buzz agent runtimes.
-entrypoint: Inspect `buzz-hermes-*` and `buzz-mill-docs-codex.service`.
+entrypoint: Inspect `buzz-hermes-*`, `mill-docs-coding-agent.timer`, and the MillDocs Buzz runbook.
 verification: Verify live runtimes and compare current Buzz releases with the self-hosting criteria.
 update_when: The hosted runtime boundary, Buzz deployment model, or self-hosting criteria change.
 ---
@@ -39,9 +39,10 @@ Do not self-host the Buzz relay or replace existing Hermes delivery surfaces
 with Buzz.
 
 Expose the configured NUC Hermes profiles to the hosted Millers community as
-separate, low-privilege agent runtimes. Keep the bounded Mill Docs Codex worker
-for its project-specific sandbox. This is a client integration, not a Buzz
-infrastructure deployment. Hermes remains the primary agent runtime.
+separate, low-privilege agent runtimes. MillDocs Buzz is owned by its dedicated
+Cloudflare Worker; the NUC only executes its typed Linear coding queue. This is
+a client integration, not a Buzz infrastructure deployment. Hermes remains the
+primary agent runtime for the other profiles.
 
 Current assessment:
 
@@ -57,11 +58,11 @@ Buzz community ─WSS─> buzz-acp ──┼─> Hermes ACP profile B ─> decla
                   one identity    └─> Hermes ACP profile N ─> declared repos
                   per profile
 
-Buzz community ─WSS─> buzz-acp ─ACP─> codex-acp ─> bounded Mill Docs worker
+Buzz community ─HTTP─> dedicated Flue 2 Worker ─> Linear queue ─> NUC executor
 ```
 
 `hosts/nuc/default.nix` owns the generated `buzz-hermes-<profile>.service`
-units and `buzz-mill-docs-codex.service`. Each Hermes unit uses the profile's
+units and the MillDocs coding-agent timer. Each Hermes unit uses the profile's
 materialized home, package, environment, and declared host mounts. Each has a
 dedicated Nostr identity from agenix, one channel matching its repository
 boundary, owner-only mention routing, lazy ACP startup, no inbound port, and no
@@ -71,7 +72,7 @@ Project ownership follows the canonical agents workspace: Finn owns the
 `finances` checkout and forum; Anne and Betty share `mill-docs`; Amos Burton,
 Orchestrator, and Scintillate use `general`.
 
-The Mill Docs worker keeps its exact author allowlist. Add Moni only after her
+The Cloudflare MillDocs Worker keeps its exact author allowlist. Add Moni only after her
 64-character relay pubkey is known and her identity belongs to the community.
 
 ## Reasons

--- a/docs/runbooks/deploy-nuc.md
+++ b/docs/runbooks/deploy-nuc.md
@@ -189,26 +189,30 @@ email and does not load Buzz delivery credentials. Buzz executors load the
 same dedicated identity as their profile's inbound runtime. `buzz-acp` remains
 mention-scoped inbound transport.
 
-The separate `buzz-mill-docs-codex.service` remains project-scoped. Its
-encrypted identity is `hosts/nuc/secrets/buzz-mill-docs-agent-env.age`; it uses
-the existing `/home/emiller/.codex` ChatGPT login.
+MillDocs Buzz replies are owned by the dedicated Cloudflare `mill-docs-buzz`
+Worker. The NUC keeps only `mill-docs-coding-agent.timer`, which processes typed
+Linear feedback and posts authenticated status callbacks. Its encrypted Buzz
+identity remains available for repository credentials and queue execution.
 
 Verify after a deploy or recovery:
 
 ```bash
 ssh nuc "systemctl list-units --all --no-legend 'buzz-hermes-*.service'"
 ssh nuc "systemctl show 'buzz-hermes-*.service' -p Id -p ActiveState -p MainPID -p NRestarts"
-ssh nuc 'systemctl is-active buzz-mill-docs-codex.service'
+ssh nuc 'systemctl is-active mill-docs-coding-agent.timer'
+ssh nuc 'systemctl status buzz-mill-docs-codex.service --no-pager'
 ssh nuc "journalctl -u 'buzz-hermes-*.service' -n 50 --no-pager"
 ```
 
-Expected: every configured unit is active with zero restarts and connected to
+Expected: every configured Hermes unit is active with zero restarts and connected to
 `wss://millers.communities.buzz.xyz`. Lazy mode starts the Hermes ACP child
 only after an accepted mention. The services expose no listener.
+`mill-docs-coding-agent.timer` is active, and
+`buzz-mill-docs-codex.service` is not found.
 
 ```bash
 ssh nuc "sudo systemctl restart 'buzz-hermes-*.service'"
-ssh nuc 'sudo systemctl restart buzz-mill-docs-codex.service'
+ssh nuc 'sudo systemctl start mill-docs-coding-agent.service'
 ```
 
 Create each Hermes identity through the owner-reviewed Buzz flow so the relay

--- a/hosts/nuc/default.nix
+++ b/hosts/nuc/default.nix
@@ -507,10 +507,6 @@ let
       BUZZ_HOME_CHANNEL = buzzChannelId binding.home;
       BUZZ_CLI_PATH = "${pkgs.my.buzz}/bin/buzz";
     };
-  buzzMillDocsChannelId = buzzChannelId "mill-docs";
-  buzzMillDocsCodexAcp = pkgs.writeShellScriptBin "mill-docs-codex-acp" ''
-    exec ${pkgs.my.codex-acp}/bin/codex-acp "$@"
-  '';
   mkBuzzHermesService =
     profile:
     let
@@ -2429,66 +2425,6 @@ in
     mode = "0400";
   };
 
-  systemd.services.buzz-mill-docs-codex = {
-    description = "Buzz mention worker for mill-docs";
-    after = [ "network-online.target" ];
-    wants = [ "network-online.target" ];
-    wantedBy = [ "multi-user.target" ];
-    environment = {
-      HOME = "/home/emiller";
-      CODEX_HOME = "/home/emiller/.codex";
-      NO_BROWSER = "1";
-      BUZZ_RELAY_URL = "wss://millers.communities.buzz.xyz";
-      BUZZ_ACP_AGENT_OWNER = buzzMillDocsOwnerPubkey;
-      BUZZ_ACP_AGENT_COMMAND = "${buzzMillDocsCodexAcp}/bin/mill-docs-codex-acp";
-      BUZZ_ACP_AGENT_ARGS = "";
-      BUZZ_ACP_AGENTS = "1";
-      BUZZ_ACP_SUBSCRIBE = "mentions";
-      BUZZ_ACP_CHANNELS = buzzMillDocsChannelId;
-      BUZZ_ACP_RESPOND_TO = "owner-only";
-      BUZZ_ACP_ALLOWED_RESPOND_TO = "owner-only";
-      BUZZ_ACP_HEARTBEAT_INTERVAL = "0";
-      BUZZ_ACP_MEMORY = "false";
-    };
-    serviceConfig = {
-      Type = "simple";
-      User = "emiller";
-      Group = "users";
-      WorkingDirectory = millDocsVaultPath;
-      ExecStart = "${pkgs.my.buzz}/bin/buzz-acp";
-      EnvironmentFile = config.age.secrets.buzz-mill-docs-agent-env.path;
-      Restart = "always";
-      RestartSec = "10s";
-      UMask = "0077";
-      ProtectSystem = "strict";
-      ProtectHome = "tmpfs";
-      BindPaths = [
-        millDocsVaultPath
-        "/home/emiller/.codex"
-      ];
-      BindReadOnlyPaths = [ "/home/emiller/obsidian-vault" ];
-      NoNewPrivileges = true;
-      PrivateTmp = true;
-      PrivateDevices = true;
-      CapabilityBoundingSet = "";
-      LockPersonality = true;
-      ProtectClock = true;
-      ProtectControlGroups = true;
-      ProtectHostname = true;
-      ProtectKernelLogs = true;
-      ProtectKernelModules = true;
-      ProtectKernelTunables = true;
-      RestrictAddressFamilies = [
-        "AF_UNIX"
-        "AF_INET"
-        "AF_INET6"
-      ];
-      RestrictRealtime = true;
-      RestrictSUIDSGID = true;
-      SystemCallArchitectures = "native";
-    };
-  };
-
   systemd.services.buzz-hermes-amosburton = mkBuzzHermesService "amosburton";
   systemd.services.buzz-hermes-anne = mkBuzzHermesService "anne";
   systemd.services.buzz-hermes-betty = mkBuzzHermesService "betty";
@@ -2572,7 +2508,7 @@ in
       NPM_CONFIG_CACHE = "${millDocsCodingAgentStateDir}/cache/npm";
       XDG_DATA_HOME = "${millDocsCodingAgentStateDir}/data";
       XDG_STATE_HOME = "${millDocsCodingAgentStateDir}/state";
-      BUZZ_FEEDBACK_STATUS_URL = "https://mill-docs-agents.${tailnet}/channels/buzz/feedback";
+      BUZZ_FEEDBACK_STATUS_URL = "https://mill-docs-buzz.edmund-a-miller.workers.dev/channels/buzz/feedback";
       BUZZ_RELAY_URL = "https://millers.communities.buzz.xyz";
     };
     serviceConfig = {

--- a/packages/quill/default.nix
+++ b/packages/quill/default.nix
@@ -1,5 +1,4 @@
 {
-  lib,
   stdenvNoCC,
   fetchFromGitHub,
 }:

--- a/packages/quill/package-harness.json
+++ b/packages/quill/package-harness.json
@@ -2,7 +2,5 @@
   "source": "https://github.com/digimata/quill.git",
   "ref": "7ea94e27cbf403dd1fa14f460b1bea56bf78477d",
   "patches": [],
-  "checks": [
-    ["swift", "build", "-c", "release"]
-  ]
+  "checks": [["swift", "build", "-c", "release"]]
 }

--- a/statix.toml
+++ b/statix.toml
@@ -1,0 +1,2 @@
+disabled = ["repeated_keys"]
+ignore = [".direnv"]

--- a/tests/test_mill_docs_coding_agent.py
+++ b/tests/test_mill_docs_coding_agent.py
@@ -11,7 +11,8 @@ class MillDocsCodingAgentTest(unittest.TestCase):
         self.assertIn('millDocsCodingAgentRepo = "/var/lib/mill-docs-coding-agent/repo";', source)
         self.assertIn("systemd.services.mill-docs-coding-agent", source)
         self.assertIn("systemd.timers.mill-docs-coding-agent", source)
-        self.assertIn('BUZZ_FEEDBACK_STATUS_URL = "https://mill-docs-agents.${tailnet}/channels/buzz/feedback";', source)
+        self.assertIn('BUZZ_FEEDBACK_STATUS_URL = "https://mill-docs-buzz.edmund-a-miller.workers.dev/channels/buzz/feedback";', source)
+        self.assertNotIn("systemd.services.buzz-mill-docs-codex", source)
         self.assertIn('git remote add github', source)
         self.assertNotIn('WorkingDirectory = millDocsVaultPath;\n      ExecStart = "${millDocsCodingAgent', source)
 


### PR DESCRIPTION
## Summary
- remove the NUC direct Buzz responder
- retain the MillDocs Linear coding queue timer
- point authenticated feedback callbacks at the dedicated Flue 2 Worker

## Verification
- focused Python tests: 5 passed
- NUC configuration build passed
- agent test-confidence audit passed

Depends on the MillDocs Flue 2 Worker cutover.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/edmundmiller/dotfiles/pull/197" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->