### PR TITLE
fix(nuc): persist coding-agent acpx state

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1205,6 +1205,11 @@
                 inherit pkgs;
               };
 
+              nuc-mill-docs-coding-agent = import ./hosts/nuc/_tests/mill-docs-coding-agent.nix {
+                nixosConfig = self.nixosConfigurations.nuc;
+                inherit pkgs;
+              };
+
               nuc-buzz-hermes-community-runtime = import ./hosts/nuc/_tests/buzz-hermes-community-runtime.nix {
                 nixosConfig = self.nixosConfigurations.nuc;
                 inherit pkgs;

--- a/hosts/nuc/_tests/mill-docs-coding-agent.nix
+++ b/hosts/nuc/_tests/mill-docs-coding-agent.nix
@@ -1,0 +1,31 @@
+{ nixosConfig, pkgs }:
+let
+  cfg = nixosConfig.config;
+  service = cfg.systemd.services.mill-docs-coding-agent;
+  acpxDir = "/var/lib/mill-docs-coding-agent/acpx";
+  failures = builtins.filter (assertion: !assertion.test) [
+    {
+      test = builtins.elem "d ${acpxDir} 0700 emiller users -" cfg.systemd.tmpfiles.rules;
+      msg = "Mill Docs coding agent must create its private acpx state directory.";
+    }
+    {
+      test = service.environment.HOME == "/home/emiller";
+      msg = "Mill Docs coding agent must preserve the user home used by SSH.";
+    }
+    {
+      test =
+        service.serviceConfig.ProtectHome == "read-only"
+        && service.serviceConfig.BindPaths == [ "${acpxDir}:/home/emiller/.acpx" ];
+      msg = "Mill Docs coding agent must bind writable acpx state into its protected home.";
+    }
+  ];
+in
+pkgs.runCommand "nuc-mill-docs-coding-agent" { } ''
+  if [ ${toString (builtins.length failures)} -ne 0 ]; then
+    cat >&2 <<'EOF'
+  ${builtins.concatStringsSep "\n" (map (failure: failure.msg) failures)}
+  EOF
+    exit 1
+  fi
+  touch "$out"
+''

--- a/hosts/nuc/default.nix
+++ b/hosts/nuc/default.nix
@@ -436,6 +436,7 @@ let
   };
   millDocsVaultPath = "/home/emiller/mill-docs";
   millDocsCodingAgentStateDir = "/var/lib/mill-docs-coding-agent";
+  millDocsCodingAgentAcpxDir = "${millDocsCodingAgentStateDir}/acpx";
   millDocsCodingAgentRepo = "/var/lib/mill-docs-coding-agent/repo";
   millDocsBuzzGitUrl = "https://millers.communities.buzz.xyz/git/fdb266e13b8a216bcb47132c5451fa4cac6b70730bd6d9952b9609362cc84d4c/mill-docs";
   millDocsGithubGitUrl = "git@github.com:edmundmiller/mill-docs.git";
@@ -2380,6 +2381,7 @@ in
   services.tailscale.extraSetFlags = [ "--advertise-routes=192.168.1.0/24" ];
   systemd.tmpfiles.rules = [
     "d ${millDocsVaultPath} 0755 emiller users -"
+    "d ${millDocsCodingAgentAcpxDir} 0700 emiller users -"
 
   ];
 
@@ -2528,6 +2530,7 @@ in
       UMask = "0077";
       ProtectSystem = "strict";
       ProtectHome = "read-only";
+      BindPaths = [ "${millDocsCodingAgentAcpxDir}:/home/emiller/.acpx" ];
       ReadWritePaths = [
         millDocsCodingAgentStateDir
       ];


### PR DESCRIPTION
## Summary
- create private acpx state under the coding-agent StateDirectory
- bind it into the protected user home so acpx can create session state
- preserve `/home/emiller` for SSH key discovery

## Verification
- `nix build .#checks.aarch64-darwin.nuc-mill-docs-coding-agent --no-link`
- evaluated bind: `/var/lib/mill-docs-coding-agent/acpx:/home/emiller/.acpx`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/edmundmiller/dotfiles/pull/198" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->