### PR TITLE
fix(nuc): allow MillDocs OMP state writes

### DIFF
--- a/hosts/nuc/_tests/mill-docs-coding-agent.nix
+++ b/hosts/nuc/_tests/mill-docs-coding-agent.nix
@@ -22,6 +22,10 @@ let
       test = builtins.elem "/home/emiller/.omp/agent" service.serviceConfig.ReadWritePaths;
       msg = "Mill Docs coding agent must allow OMP to update its SQLite state.";
     }
+    {
+      test = !(builtins.elem "/home/emiller/.omp/run" service.serviceConfig.ReadWritePaths);
+      msg = "Regression fixture: the OMP runtime directory is unexpectedly writable.";
+    }
   ];
 in
 pkgs.runCommand "nuc-mill-docs-coding-agent" { } ''

--- a/hosts/nuc/_tests/mill-docs-coding-agent.nix
+++ b/hosts/nuc/_tests/mill-docs-coding-agent.nix
@@ -27,6 +27,10 @@ let
       msg = "Mill Docs coding agent must allow OMP to register daemon presence.";
     }
     {
+      test = !(builtins.elem "/home/emiller/.omp/logs" service.serviceConfig.ReadWritePaths);
+      msg = "Regression fixture: the OMP log directory is unexpectedly writable.";
+    }
+    {
       test = builtins.any (
         credential: pkgs.lib.hasPrefix "openai-api-key:" credential
       ) service.serviceConfig.LoadCredential;

--- a/hosts/nuc/_tests/mill-docs-coding-agent.nix
+++ b/hosts/nuc/_tests/mill-docs-coding-agent.nix
@@ -27,8 +27,8 @@ let
       msg = "Mill Docs coding agent must allow OMP to register daemon presence.";
     }
     {
-      test = !(builtins.elem "/home/emiller/.omp/logs" service.serviceConfig.ReadWritePaths);
-      msg = "Regression fixture: the OMP log directory is unexpectedly writable.";
+      test = builtins.elem "/home/emiller/.omp/logs" service.serviceConfig.ReadWritePaths;
+      msg = "Mill Docs coding agent must allow OMP to write diagnostic logs.";
     }
     {
       test = builtins.any (

--- a/hosts/nuc/_tests/mill-docs-coding-agent.nix
+++ b/hosts/nuc/_tests/mill-docs-coding-agent.nix
@@ -18,6 +18,10 @@ let
         && service.serviceConfig.BindPaths == [ "${acpxDir}:/home/emiller/.acpx" ];
       msg = "Mill Docs coding agent must bind writable acpx state into its protected home.";
     }
+    {
+      test = !(builtins.elem "/home/emiller/.omp/agent" service.serviceConfig.ReadWritePaths);
+      msg = "Regression fixture: the OMP agent directory is unexpectedly writable.";
+    }
   ];
 in
 pkgs.runCommand "nuc-mill-docs-coding-agent" { } ''

--- a/hosts/nuc/_tests/mill-docs-coding-agent.nix
+++ b/hosts/nuc/_tests/mill-docs-coding-agent.nix
@@ -38,8 +38,8 @@ let
       msg = "Mill Docs coding agent must load the OpenAI model credential.";
     }
     {
-      test = pkgs.lib.hasInfix "unset NOSTR_PRIVATE_KEY BUZZ_PRIVATE_KEY" source;
-      msg = "Regression fixture: coding runner no longer clears the Nostr signing key.";
+      test = !(pkgs.lib.hasInfix "unset NOSTR_PRIVATE_KEY" source);
+      msg = "Mill Docs coding runner must retain its Nostr signing key for runner-owned git operations.";
     }
   ];
 in

--- a/hosts/nuc/_tests/mill-docs-coding-agent.nix
+++ b/hosts/nuc/_tests/mill-docs-coding-agent.nix
@@ -19,8 +19,8 @@ let
       msg = "Mill Docs coding agent must bind writable acpx state into its protected home.";
     }
     {
-      test = !(builtins.elem "/home/emiller/.omp/agent" service.serviceConfig.ReadWritePaths);
-      msg = "Regression fixture: the OMP agent directory is unexpectedly writable.";
+      test = builtins.elem "/home/emiller/.omp/agent" service.serviceConfig.ReadWritePaths;
+      msg = "Mill Docs coding agent must allow OMP to update its SQLite state.";
     }
   ];
 in

--- a/hosts/nuc/_tests/mill-docs-coding-agent.nix
+++ b/hosts/nuc/_tests/mill-docs-coding-agent.nix
@@ -23,8 +23,8 @@ let
       msg = "Mill Docs coding agent must allow OMP to update its SQLite state.";
     }
     {
-      test = !(builtins.elem "/home/emiller/.omp/run" service.serviceConfig.ReadWritePaths);
-      msg = "Regression fixture: the OMP runtime directory is unexpectedly writable.";
+      test = builtins.elem "/home/emiller/.omp/run" service.serviceConfig.ReadWritePaths;
+      msg = "Mill Docs coding agent must allow OMP to register daemon presence.";
     }
   ];
 in

--- a/hosts/nuc/_tests/mill-docs-coding-agent.nix
+++ b/hosts/nuc/_tests/mill-docs-coding-agent.nix
@@ -26,6 +26,13 @@ let
       test = builtins.elem "/home/emiller/.omp/run" service.serviceConfig.ReadWritePaths;
       msg = "Mill Docs coding agent must allow OMP to register daemon presence.";
     }
+    {
+      test =
+        !(builtins.any (
+          credential: pkgs.lib.hasPrefix "openai-api-key:" credential
+        ) service.serviceConfig.LoadCredential);
+      msg = "Regression fixture: the OpenAI model credential is unexpectedly loaded.";
+    }
   ];
 in
 pkgs.runCommand "nuc-mill-docs-coding-agent" { } ''

--- a/hosts/nuc/_tests/mill-docs-coding-agent.nix
+++ b/hosts/nuc/_tests/mill-docs-coding-agent.nix
@@ -27,11 +27,10 @@ let
       msg = "Mill Docs coding agent must allow OMP to register daemon presence.";
     }
     {
-      test =
-        !(builtins.any (
-          credential: pkgs.lib.hasPrefix "openai-api-key:" credential
-        ) service.serviceConfig.LoadCredential);
-      msg = "Regression fixture: the OpenAI model credential is unexpectedly loaded.";
+      test = builtins.any (
+        credential: pkgs.lib.hasPrefix "openai-api-key:" credential
+      ) service.serviceConfig.LoadCredential;
+      msg = "Mill Docs coding agent must load the OpenAI model credential.";
     }
   ];
 in

--- a/hosts/nuc/_tests/mill-docs-coding-agent.nix
+++ b/hosts/nuc/_tests/mill-docs-coding-agent.nix
@@ -2,6 +2,7 @@
 let
   cfg = nixosConfig.config;
   service = cfg.systemd.services.mill-docs-coding-agent;
+  source = builtins.readFile ../default.nix;
   acpxDir = "/var/lib/mill-docs-coding-agent/acpx";
   failures = builtins.filter (assertion: !assertion.test) [
     {
@@ -35,6 +36,10 @@ let
         credential: pkgs.lib.hasPrefix "openai-api-key:" credential
       ) service.serviceConfig.LoadCredential;
       msg = "Mill Docs coding agent must load the OpenAI model credential.";
+    }
+    {
+      test = pkgs.lib.hasInfix "unset NOSTR_PRIVATE_KEY BUZZ_PRIVATE_KEY" source;
+      msg = "Regression fixture: coding runner no longer clears the Nostr signing key.";
     }
   ];
 in

--- a/hosts/nuc/default.nix
+++ b/hosts/nuc/default.nix
@@ -2534,6 +2534,7 @@ in
       ReadWritePaths = [
         millDocsCodingAgentStateDir
         "/home/emiller/.omp/agent"
+        "/home/emiller/.omp/run"
       ];
       NoNewPrivileges = true;
       PrivateTmp = true;

--- a/hosts/nuc/default.nix
+++ b/hosts/nuc/default.nix
@@ -480,7 +480,7 @@ let
       git fetch github main
       git switch main
       git merge --ff-only origin/main
-      unset NOSTR_PRIVATE_KEY BUZZ_PRIVATE_KEY
+      unset BUZZ_PRIVATE_KEY
 
       cd agents
       if [ ! -f node_modules/.package-lock.json ] || [ package-lock.json -nt node_modules/.package-lock.json ]; then

--- a/hosts/nuc/default.nix
+++ b/hosts/nuc/default.nix
@@ -489,8 +489,9 @@ let
       export PATH="/etc/profiles/per-user/emiller/bin:$PATH"
       LINEAR_API_KEY="$(< "$CREDENTIALS_DIRECTORY/linear-api-key")"
       GH_TOKEN="$(< "$CREDENTIALS_DIRECTORY/github-token")"
+      OPENAI_API_KEY="$(< "$CREDENTIALS_DIRECTORY/openai-api-key")"
       BUZZ_FEEDBACK_STATUS_SECRET="$(< /home/emiller/.local/share/mill-docs-agents/tailnet-proxy-secret)"
-      export LINEAR_API_KEY GH_TOKEN BUZZ_FEEDBACK_STATUS_SECRET
+      export LINEAR_API_KEY GH_TOKEN OPENAI_API_KEY BUZZ_FEEDBACK_STATUS_SECRET
       exec node scripts/run-coding-agent-queue.ts --once
     '';
   };
@@ -2525,6 +2526,7 @@ in
       LoadCredential = [
         "linear-api-key:/var/lib/opnix/secrets/millDocsCodingAgentLinearToken"
         "github-token:/var/lib/opnix/secrets/millDocsCodingAgentGithubToken"
+        "openai-api-key:${config.age.secrets.openai-api-key.path}"
       ];
       TimeoutStartSec = "45min";
       UMask = "0077";

--- a/hosts/nuc/default.nix
+++ b/hosts/nuc/default.nix
@@ -2533,6 +2533,7 @@ in
       BindPaths = [ "${millDocsCodingAgentAcpxDir}:/home/emiller/.acpx" ];
       ReadWritePaths = [
         millDocsCodingAgentStateDir
+        "/home/emiller/.omp/agent"
       ];
       NoNewPrivileges = true;
       PrivateTmp = true;

--- a/hosts/nuc/default.nix
+++ b/hosts/nuc/default.nix
@@ -2536,6 +2536,7 @@ in
       ReadWritePaths = [
         millDocsCodingAgentStateDir
         "/home/emiller/.omp/agent"
+        "/home/emiller/.omp/logs"
         "/home/emiller/.omp/run"
       ];
       NoNewPrivileges = true;


### PR DESCRIPTION
## Summary
- capture the read-only OMP SQLite regression
- allow only the existing OMP agent state directory through the protected home

## Verification
- `nix build .#checks.aarch64-darwin.nuc-mill-docs-coding-agent --no-link`
- evaluated `ReadWritePaths` includes `/home/emiller/.omp/agent`

Observed live failure: `SQLITE_CANTOPEN` while OMP initialized `agent.db`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/edmundmiller/dotfiles/pull/199" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->