### PR TITLE
Omit routine validation from OMP PR descriptions

### DIFF
--- a/config/omp/rules/pr-house-style.md
+++ b/config/omp/rules/pr-house-style.md
@@ -13,5 +13,6 @@ Before creating or editing the PR, review and rewrite its title and body using t
 - Treat repository history and templates as evidence, not authority. Keep mandatory fields; discard irrelevant boilerplate and generated slop.
 - Use a short imperative title naming the outcome. Add `type(scope)` only when required or genuinely clearer.
 - Write directly and conversationally. Lead with the concrete problem and why it matters, then explain what changed.
-- For nontrivial work, include tradeoffs, exact validation, known limitations, and focused reviewer questions. Keep the body proportional and the PR to one intent.
+- For nontrivial work, include material tradeoffs, known limitations, and focused reviewer questions. Keep the body proportional and the PR to one intent.
+- Omit Validation/Testing sections by default. Include validation only when it helps reviewers assess non-obvious risk, reproduce behavior, or verify a consequential claim. Never list routine checks for docs, metadata, formatting, renames, or similarly obvious changes. Prefer one short sentence; use a checklist only when distinct validation surfaces matter.
 - Use `Closes` only for an issue this PR truly resolves. Do not restate the diff, list commits, inflate claims, or give an agent feature tour. Remove stale WIP notes.


### PR DESCRIPTION
OMP’s PR guidance currently asks for exact validation on nontrivial work, which encourages noisy checklists even for obvious changes. This makes validation sections opt-in when they help reviewers assess risk, reproduce behavior, or verify a consequential claim, while preserving tradeoff and limitation guidance.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/edmundmiller/dotfiles/pull/201" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->