### PR TITLE
chore(deploy): pin dashboard runtime projection

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,17 +90,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1787869759,
-        "narHash": "sha256-grVCF3g/PoqJH41jD6f15+xXTEDX1c0E6BsrItcMHrU=",
+        "lastModified": 1787871696,
+        "narHash": "sha256-vPcOJzX0ZGPB7Zg4C2dvolHr7dSusWvudkEK7x8TACQ=",
         "owner": "edmundmiller",
         "repo": "agents-workspace",
-        "rev": "987e37891aab90e4e57e0383b94580af071fab48",
+        "rev": "c16051f230767695d15b0f6bd78a247d128539f4",
         "type": "github"
       },
       "original": {
         "owner": "edmundmiller",
         "repo": "agents-workspace",
-        "rev": "987e37891aab90e4e57e0383b94580af071fab48",
+        "rev": "c16051f230767695d15b0f6bd78a247d128539f4",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -108,7 +108,7 @@
     agents-workspace = {
       # The NUC's nix-private-github wrapper authenticates private GitHub
       # archive fetches without requiring a host-level SSH deployment key.
-      url = "github:edmundmiller/agents-workspace/987e37891aab90e4e57e0383b94580af071fab48";
+      url = "github:edmundmiller/agents-workspace/c16051f230767695d15b0f6bd78a247d128539f4";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.llm-agents.follows = "llm-agents";
     };


### PR DESCRIPTION
## Summary
- pin agents-workspace merge `c16051f230767695d15b0f6bd78a247d128539f4`
- deploy the production-shaped named-profile runtime projection fix

## Verification
- full NUC `nixos-rebuild build` from exact stamped commit `83c063da5e80e64985ee71f01b44d87de110e2e7`
- x86_64-linux `hermes-dashboard-profile-liveness`
- x86_64-linux `hermes-buzz-patch-stack`
- x86_64-linux `nuc-hermes-dashboard-enabled`
- x86_64-linux `nuc-buzz-hermes-community-runtime`
- x86_64-linux `nuc-hermes-v0205-package`

No live activation occurs in this PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/edmundmiller/dotfiles/pull/224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->