### PR TITLE
fix(nuc): keep agents lock pin immutable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -100,7 +100,7 @@
       "original": {
         "owner": "edmundmiller",
         "repo": "agents-workspace",
-        "rev": "35d819a160ef18a3632b99a43e9bf1dd76e8a4b8",
+        "rev": "3fcc88e3b5276ab05dd1f2a18c1912e18207b69a",
         "type": "github"
       }
     },

--- a/tests/test_hermes_cron_executors.py
+++ b/tests/test_hermes_cron_executors.py
@@ -319,7 +319,7 @@ class HermesCronExecutorTests(unittest.TestCase):
         ):
             self.assertIn(contract, overlay)
 
-    def test_agents_workspace_url_and_lock_revision_match(self):
+    def test_agents_workspace_url_and_lock_revisions_match(self):
         flake = (ROOT / "flake.nix").read_text(encoding="utf-8")
         lock = json.loads((ROOT / "flake.lock").read_text(encoding="utf-8"))
         match = re.search(
@@ -331,6 +331,10 @@ class HermesCronExecutorTests(unittest.TestCase):
         self.assertEqual(
             match.group(1),
             lock["nodes"]["agents-workspace"]["locked"]["rev"],
+        )
+        self.assertEqual(
+            match.group(1),
+            lock["nodes"]["agents-workspace"]["original"]["rev"],
         )
 
     def test_darwin_common_checks_do_not_evaluate_nuc_or_deploy(self):


### PR DESCRIPTION
## Summary
- keep the agents-workspace input URL, locked revision, and original lock revision identical
- add a focused regression so `--no-update-lock-file` deployments cannot silently depend on a lock rewrite

## Verification
- `python3 tests/test_hermes_cron_executors.py -q` (24 passed)
- `nix build --no-link .#checks.aarch64-darwin.hermes-cron-executor-source-tests`
- `nix flake metadata --json --no-update-lock-file .`
- `nix flake archive --no-update-lock-file`
- independent read-only review: PASS

No NUC deployment or service mutation is included.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/edmundmiller/dotfiles/pull/225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->