### PR TITLE
fix(renovate): cut noise and make the self-hosted runner succeed

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,3 +1,4 @@
+# Self-hosted Renovate (not the Mend GitHub App). See docs/runbooks/renovate.md.
 name: Renovate
 
 on:
@@ -26,18 +27,22 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v20
+        with:
+          extra-conf: accept-flake-config = true
 
       - name: Run Renovate
         env:
           LOG_LEVEL: info
+          NIX_CONFIG: "accept-flake-config = true"
           RENOVATE_PLATFORM: github
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN }}
           GITHUB_COM_TOKEN: ${{ secrets.RENOVATE_TOKEN }}
-          RENOVATE_ALLOWED_COMMANDS: '["^nix run \\.#renovate-update-nix-hashes$"]'
+          RENOVATE_GIT_AUTHOR: "Renovate Bot <renovate@users.noreply.github.com>"
+          RENOVATE_ALLOWED_COMMANDS: '["^nix run --accept-flake-config \\.#renovate-update-nix-hashes$"]'
         run: |
           test -n "$RENOVATE_TOKEN" || {
             echo "RENOVATE_TOKEN repository secret is required" >&2
             exit 1
           }
-          nix run nixpkgs#renovate
+          nix run --accept-flake-config nixpkgs#renovate

--- a/bin/check-patch-locality
+++ b/bin/check-patch-locality
@@ -2,8 +2,9 @@
 
 invalid=0
 for path in "$@"; do
-  if [[ ! "$path" =~ ^(packages|overlays)/[^/]+/patches/[^/]+\.patch$ ]]; then
-    echo "Patch must live at packages/<name>/patches/*.patch or overlays/<name>/patches/*.patch: $path" >&2
+  if [[ ! "$path" =~ ^(packages|overlays)/[^/]+/patches/[^/]+\.patch$ ]] &&
+    [[ ! "$path" =~ ^skills/overlays/[^/]+/[^/]+\.patch$ ]]; then
+    echo "Patch must live at packages/<name>/patches/*.patch, overlays/<name>/patches/*.patch, or skills/overlays/<name>/*.patch: $path" >&2
     invalid=1
   fi
 done

--- a/config/herdr/config.toml
+++ b/config/herdr/config.toml
@@ -35,8 +35,8 @@ delivery = "herdr"
 
 [ui.sound]
 enabled = false
-# Amp plays this macOS system sound directly when an agent finishes.
-done_path = "/System/Library/Sounds/Submarine.aiff"
+# Herdr only accepts mp3 paths. Set a local mp3 on a host if you want
+# a finish sound; do not pin a macOS system sound in this template.
 
 [session]
 resume_agents_on_restore = true

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,8 @@ update_when: A canonical doc is added, moved, or changes ownership.
 ### Runbooks
 
 - [runbooks/README.md](./runbooks/README.md) — operational runbook index
+- [runbooks/renovate.md](./runbooks/renovate.md) — self-hosted Renovate runner,
+  dashboard, and expected PR shape
 
 ## Conventions
 

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,7 +1,12 @@
-# Runbooks
+---
+purpose: Index operational recovery runbooks for this repository.
+applies_to: Choosing which runbook to read for a host, secret, or automation failure.
+entrypoint: Use the table row that matches the failure.
+verification: Follow the linked runbook and run its named live check.
+update_when: A runbook is added, renamed, or changes ownership.
+---
 
-- [LookAway Busylight / Luxafor integration](./lookaway-busylight.md)
-- [Remove Installer Nix Profile](./remove-installer-nix-profile.md)
+# Runbooks
 
 Operational runbooks for the dotfiles infrastructure.
 
@@ -11,5 +16,6 @@ Operational runbooks for the dotfiles infrastructure.
 | ------------------------------------------------------------------ | ----------------------------------------------------------------- |
 | [rebuild-failure.md](rebuild-failure.md)                           | `darwin-rebuild` or `nixos-rebuild` fails                         |
 | [deploy-nuc.md](deploy-nuc.md)                                     | Deploying to the NUC server via deploy-rs                         |
+| [renovate.md](renovate.md)                                         | Renovate is quiet, noisy, or its Action is failing                |
 | [secret-rotation.md](secret-rotation.md)                           | Rotating secrets managed by agenix                                |
 | [remove-installer-nix-profile.md](remove-installer-nix-profile.md) | `nix` resolves to a stale installer profile instead of system nix |

--- a/docs/runbooks/renovate.md
+++ b/docs/runbooks/renovate.md
@@ -27,15 +27,15 @@ a second runner would duplicate PRs.
 
 ## Expected PR shape
 
-| Branch / group | What lands |
-| --- | --- |
-| `renovate/lock-file-maintenance` | Monday `flake.lock` refresh (branch automerge) |
-| `renovate/javascript-package-dependencies` | Non-major npm/bun bumps |
-| `renovate/github-actions` | Non-major Actions and digest pins |
-| `renovate/nix-flake-inputs` | Versioned flake inputs only |
-| `renovate/repo-local-nix-package-patches` | Regex-managed Nix package patches plus hash refresh |
-| `renovate/herdr`, `renovate/hunk` | Overlay/harness + flake tag, no automerge |
-| Major updates | Stay on the Dependency Dashboard until checked |
+| Branch / group                             | What lands                                          |
+| ------------------------------------------ | --------------------------------------------------- |
+| `renovate/lock-file-maintenance`           | Monday `flake.lock` refresh (branch automerge)      |
+| `renovate/javascript-package-dependencies` | Non-major npm/bun bumps                             |
+| `renovate/github-actions`                  | Non-major Actions and digest pins                   |
+| `renovate/nix-flake-inputs`                | Versioned flake inputs only                         |
+| `renovate/repo-local-nix-package-patches`  | Regex-managed Nix package patches plus hash refresh |
+| `renovate/herdr`, `renovate/hunk`          | Overlay/harness + flake tag, no automerge           |
+| Major updates                              | Stay on the Dependency Dashboard until checked      |
 
 Unversioned flake pins and private inputs (`agents-workspace`, `tnote`) are not
 individual PRs. Bump those with `hey upgrade` when the PAT cannot see the repo.

--- a/docs/runbooks/renovate.md
+++ b/docs/runbooks/renovate.md
@@ -1,0 +1,56 @@
+---
+purpose: Explain how self-hosted Renovate runs in this repo and how to verify it.
+applies_to: Renovate config, the scheduled Action, or dependency-update PR triage.
+entrypoint: Read renovate.json, then .github/workflows/renovate.yml.
+verification: Confirm the Dependency Dashboard issue and the latest Renovate workflow run.
+update_when: The runner, token owner, schedules, grouping, or hash-refresh command changes.
+---
+
+# Renovate
+
+This repository self-hosts Renovate through `.github/workflows/renovate.yml`.
+It does **not** use the Mend Renovate GitHub App. Do not install that app here;
+a second runner would duplicate PRs.
+
+## How it runs
+
+- Schedule: Actions cron `17 10 * * *` (about 05:17 America/Chicago).
+- Config schedule: weekday mornings `04:00-08:00` America/Chicago, so the daily
+  job is inside the window.
+- Auth: repository secret `RENOVATE_TOKEN` (a fine-grained PAT). Pull requests
+  and the Dependency Dashboard issue are authored as that token's user
+  (`edmundmiller` today), **not** `app/renovate`.
+- Hash refresh: `postUpgradeTasks` runs
+  `nix run --accept-flake-config .#renovate-update-nix-hashes`.
+- Herdr and Hunk release PRs stay manual for
+  `.github/workflows/renovate-patch-repair.yml`.
+
+## Expected PR shape
+
+| Branch / group | What lands |
+| --- | --- |
+| `renovate/lock-file-maintenance` | Monday `flake.lock` refresh (branch automerge) |
+| `renovate/javascript-package-dependencies` | Non-major npm/bun bumps |
+| `renovate/github-actions` | Non-major Actions and digest pins |
+| `renovate/nix-flake-inputs` | Versioned flake inputs only |
+| `renovate/repo-local-nix-package-patches` | Regex-managed Nix package patches plus hash refresh |
+| `renovate/herdr`, `renovate/hunk` | Overlay/harness + flake tag, no automerge |
+| Major updates | Stay on the Dependency Dashboard until checked |
+
+Unversioned flake pins and private inputs (`agents-workspace`, `tnote`) are not
+individual PRs. Bump those with `hey upgrade` when the PAT cannot see the repo.
+
+## Verify
+
+1. Open the Dependency Dashboard issue titled **Dependency Dashboard**.
+   It should not list `lookupUpdates error` for the private flake inputs.
+2. Actions → **Renovate** → latest `schedule` or `workflow_dispatch` run is
+   green, or only fails for an unrelated runner problem.
+3. To force a retry: run the workflow manually, or check a box on the
+   dashboard (`rebase`, `unlimit`, or create-all rate-limited PRs).
+4. A repo-local Nix package PR must rewrite source hashes in the same commit
+   as the version bump. If GitHub shows `renovate/artifacts` failed, do not
+   merge; rebase from the dashboard after the hash command is fixed.
+
+Live checks: `gh issue list --search 'Dependency Dashboard in:title'` and
+`gh run list --workflow=renovate.yml --limit 5`.

--- a/flake.nix
+++ b/flake.nix
@@ -286,11 +286,17 @@
               HERDR_HASH="$hash" perl -0pi -e 's/(^[[:space:]]*hash = ")[^"]+(";$)/$1 . $ENV{HERDR_HASH} . $2/em' "$file"
             }
 
+            flake_package_exists() {
+              local attr="$1"
+              nix --accept-flake-config eval --raw ".#packages.x86_64-linux.''${attr}.name" >/dev/null 2>&1 \
+                || nix --accept-flake-config eval --raw ".#packages.aarch64-darwin.''${attr}.name" >/dev/null 2>&1
+            }
+
             while IFS= read -r file; do
               [[ -f "$file" ]] || continue
               if [[ "$file" == "flake.nix" ]]; then
                 echo "Refreshing flake lock for Hunk ($file)"
-                nix flake update hunk
+                nix --accept-flake-config flake update hunk
                 continue
               fi
               if [[ "$file" == "overlays/herdr/default.nix" ]]; then
@@ -299,8 +305,12 @@
                 continue
               fi
               attr=$(attr_for_file "$file")
+              if ! flake_package_exists "$attr"; then
+                echo "Skipping Nix hash refresh for ''${attr} (''${file}); not a flake package output."
+                continue
+              fi
               echo "Refreshing Nix hashes for .#''${attr} (''${file}) with nix-update"
-              nix-update --flake --version=skip --build "''${attr}"
+              nix-update --flake --version=skip "''${attr}"
             done <<< "$changed_files"
           '';
         };

--- a/hosts/meshify/omarchy/README.md
+++ b/hosts/meshify/omarchy/README.md
@@ -224,12 +224,12 @@ concealed or multiline fields using the 1Password desktop application:
 
 The separate `meshify-omamail` secure item contains:
 
-| Field                          | Contents                                      |
-| ------------------------------ | --------------------------------------------- |
-| `omamail-accounts`             | Entire `~/.config/omamail/accounts.json` file |
-| `omamail-credentials`          | Entire Gmail OAuth client configuration       |
-| `omamail-gmail-refresh-token`  | Gmail refresh token from the system keyring   |
-| `omamail-fastmail-password`    | Fastmail app password from the system keyring |
+| Field                         | Contents                                      |
+| ----------------------------- | --------------------------------------------- |
+| `omamail-accounts`            | Entire `~/.config/omamail/accounts.json` file |
+| `omamail-credentials`         | Entire Gmail OAuth client configuration       |
+| `omamail-gmail-refresh-token` | Gmail refresh token from the system keyring   |
+| `omamail-fastmail-password`   | Fastmail app password from the system keyring |
 
 The references are declared in `manifest.json`. Do not commit the resolved
 values. Restore writes private files with mode `0600`; application-owned

--- a/hosts/meshify/omarchy/config/omarchy/plugins/edmundmiller.lock/manifest.json
+++ b/hosts/meshify/omarchy/config/omarchy/plugins/edmundmiller.lock/manifest.json
@@ -5,9 +5,7 @@
   "version": "1.0.0",
   "author": "Omarchy",
   "description": "Quickshell session lock with separate password and fingerprint PAM flows.",
-  "kinds": [
-    "service"
-  ],
+  "kinds": ["service"],
   "keepLoaded": true,
   "entryPoints": {
     "service": "Service.qml"

--- a/hosts/meshify/omarchy/config/omarchy/shell.json
+++ b/hosts/meshify/omarchy/config/omarchy/shell.json
@@ -144,10 +144,6 @@
     }
   ],
   "version": 1,
-  "disabledPlugins": [
-    "omarchy.lock"
-  ],
-  "cloneSourceRestores": [
-    "edmundmiller.lock"
-  ]
+  "disabledPlugins": ["omarchy.lock"],
+  "cloneSourceRestores": ["edmundmiller.lock"]
 }

--- a/hosts/meshify/omarchy/docs/bluetooth-airpods.md
+++ b/hosts/meshify/omarchy/docs/bluetooth-airpods.md
@@ -93,10 +93,10 @@ A complete result has `Paired: yes`, `Bonded: yes`, `Trusted: yes`, and
 after service discovery; Omapods normalizes it back to `Edmund’s AirPods Pro`,
 so those names are the same hardware. The known meshify devices identify as:
 
-| Device | Model number | Omapods model |
-| --- | --- | --- |
-| Edmund's AirPods Pro | `A3063` | AirPods Pro 3 |
-| Edmund's AirPods Max | `A3184` | AirPods Max (USB-C) |
+| Device               | Model number | Omapods model       |
+| -------------------- | ------------ | ------------------- |
+| Edmund's AirPods Pro | `A3063`      | AirPods Pro 3       |
+| Edmund's AirPods Max | `A3184`      | AirPods Max (USB-C) |
 
 Discover Bluetooth addresses live instead of caching them here. Never commit
 the pairing keys under `~/.config/AirPodsTrayApp`; re-pairing remains the

--- a/modules/shell/herdr/AGENTS.md
+++ b/modules/shell/herdr/AGENTS.md
@@ -13,3 +13,7 @@ declared NixOS Hermes profiles.
 use a plain login shell, not fall back to jmux/tmux and create a startup loop.
 Optional `tmux/herdr.conf` popup integration does not transfer startup ownership
 from Herdr to tmux.
+
+`modules.shell.herdr.tnote.enable` (default true) installs the packaged tnote CLI
+and its Herdr plugin. The config-check VM test disables it so CI does not
+evaluate the private `tnote` flake input.

--- a/modules/shell/herdr/_tests/vm-test.nix
+++ b/modules/shell/herdr/_tests/vm-test.nix
@@ -124,6 +124,9 @@ dotfilesLib.my.mkServiceVmTest {
       modules.shell.tmux.enable = false;
 
       modules.shell.herdr.enable = true;
+      # tnote is a private flake input. Interpolating pkgs.my.tnote 404s in
+      # GitHub Actions. This test asserts activated config.toml, not tnote.
+      modules.shell.herdr.tnote.enable = false;
       # Keep the harness minimal: each integration reaches into a
       # `modules.agents.*` / `modules.services.*` module that is not imported
       # here. They default to true, and disabling them short-circuits those

--- a/modules/shell/herdr/default.nix
+++ b/modules/shell/herdr/default.nix
@@ -21,30 +21,34 @@ let
     ++ optional cfg.vercelSandbox.enable pkgs.my.herdr-vercel-sandbox-plugin;
   };
   caBundle = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
-  launchPath = concatStringsSep ":" [
-    "${pkgs.my.rift}/bin"
-    "${pkgs.my.tnote}/bin"
-    "/etc/profiles/per-user/${config.user.name}/bin"
-    "/run/current-system/sw/bin"
-    "${config.user.home}/.nix-profile/bin"
-    "${config.user.home}/.pi/agent/bin"
-    "${config.user.home}/.bun/bin"
-    "${config.user.home}/.local/bin"
-    "${config.user.home}/.pixi/bin"
-    "${config.user.home}/.cargo/bin"
-    "${pkgs.cargo}/bin"
-    "${pkgs.rustc}/bin"
-    # Marketplace plugins invoke Node and Bun after installation.
-    "${pkgs.nodejs}/bin"
-    "${pkgs.bun}/bin"
-    config.dotfiles.binDir
-    "/nix/var/nix/profiles/default/bin"
-    "/usr/local/bin"
-    "/usr/bin"
-    "/bin"
-    "/usr/sbin"
-    "/sbin"
-  ];
+  launchPath = concatStringsSep ":" (
+    [
+      "${pkgs.my.rift}/bin"
+    ]
+    ++ optional cfg.tnote.enable "${pkgs.my.tnote}/bin"
+    ++ [
+      "/etc/profiles/per-user/${config.user.name}/bin"
+      "/run/current-system/sw/bin"
+      "${config.user.home}/.nix-profile/bin"
+      "${config.user.home}/.pi/agent/bin"
+      "${config.user.home}/.bun/bin"
+      "${config.user.home}/.local/bin"
+      "${config.user.home}/.pixi/bin"
+      "${config.user.home}/.cargo/bin"
+      "${pkgs.cargo}/bin"
+      "${pkgs.rustc}/bin"
+      # Marketplace plugins invoke Node and Bun after installation.
+      "${pkgs.nodejs}/bin"
+      "${pkgs.bun}/bin"
+      config.dotfiles.binDir
+      "/nix/var/nix/profiles/default/bin"
+      "/usr/local/bin"
+      "/usr/bin"
+      "/bin"
+      "/usr/sbin"
+      "/sbin"
+    ]
+  );
   # Herdr inherits OMP's environment, where PI_CODING_AGENT_DIR points at OMP's
   # own agent dir; drop it so Pi panes use their own default agent dir.
   herdrPackages = optional (cfg.package != null) (
@@ -263,6 +267,7 @@ in
       "opencode"
     ]) "pi";
     vercelSandbox.enable = mkBoolOpt false;
+    tnote.enable = mkBoolOpt true;
     popupWidth = mkOpt int 90;
     popupHeight = mkOpt int 90;
     managePiTheme = mkBoolOpt true;
@@ -352,8 +357,8 @@ in
     modules.shell.herdr.package = mkDefault pkgs.my.herdr;
     modules.shell.herdr.configFile = mkDefault "${config.dotfiles.configDir}/herdr/config.toml";
 
-    user.packages = herdrPackages ++ [ pkgs.my.tnote ];
-    environment.systemPackages = herdrPackages ++ [ pkgs.my.tnote ];
+    user.packages = herdrPackages ++ optional cfg.tnote.enable pkgs.my.tnote;
+    environment.systemPackages = herdrPackages ++ optional cfg.tnote.enable pkgs.my.tnote;
     env.HERDR_MAIN_CODING_AGENT = cfg.mainCodingAgent;
 
     home.file.".local/bin/rift".source = lib.getExe pkgs.my.rift;
@@ -1060,7 +1065,9 @@ in
           install_plugin jhochenbaum herdr-hunk-diff
           install_plugin thanhdat77 herdr-navigator
           install_plugin edmundmiller herdr-which-key "" optional
-          install_plugin edmundmiller tnote packages/tn/herdr-plugin
+          ${optionalString cfg.tnote.enable ''
+            install_plugin edmundmiller tnote packages/tn/herdr-plugin
+          ''}
         '';
 
         home.activation.herdr-agent-integrations =

--- a/renovate.json
+++ b/renovate.json
@@ -5,14 +5,17 @@
     "enabled": true,
     "managerFilePatterns": ["/(^|/)flake\\.nix$/"]
   },
+  "timezone": "America/Chicago",
+  "schedule": ["* 4-8 * * 1-5"],
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": ["before 6am on monday"],
     "automerge": true,
     "automergeType": "branch"
   },
+  "allowedCommands": ["^nix run --accept-flake-config \\.#renovate-update-nix-hashes$"],
   "postUpgradeTasks": {
-    "commands": ["nix run .#renovate-update-nix-hashes"],
+    "commands": ["nix run --accept-flake-config .#renovate-update-nix-hashes"],
     "fileFilters": [
       "packages/**/*.nix",
       "packages/*.nix",
@@ -83,8 +86,32 @@
   ],
   "packageRules": [
     {
-      "description": "Group Nix flake input bumps for local packages and agent package sources so a Flue agent can review them together.",
+      "description": "Skip Gemfile and Poetry files; they are not the intended update surface.",
+      "matchManagers": ["bundler", "poetry"],
+      "enabled": false
+    },
+    {
+      "description": "The Actions PAT cannot ls-remote these private flake inputs. Bump them with hey upgrade when needed.",
       "matchManagers": ["nix"],
+      "matchPackageNames": [
+        "agents-workspace",
+        "tnote",
+        "https://github.com/edmundmiller/agents-workspace",
+        "https://github.com/edmundmiller/tnote"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Unversioned flake pins update through Monday lockFileMaintenance instead of per-input digest PRs.",
+      "matchManagers": ["nix"],
+      "matchDatasources": ["git-refs"],
+      "matchUpdateTypes": ["digest"],
+      "enabled": false
+    },
+    {
+      "description": "Group versioned first-party flake inputs so a Flue agent can review them together.",
+      "matchManagers": ["nix"],
+      "matchUpdateTypes": ["major", "minor", "patch", "pin"],
       "matchDepNames": ["agents-workspace", "skills-catalog", "/.*-repo$/"],
       "groupName": "@packages flake inputs",
       "groupSlug": "packages-flake-inputs",
@@ -93,43 +120,42 @@
       "automergeType": "branch"
     },
     {
-      "description": "Keep all other Nix flake input bumps available for normal Renovate review.",
+      "description": "Group remaining versioned Nix flake input bumps. Exclude lockFileMaintenance so it stays on its own Monday branch.",
       "matchManagers": ["nix"],
+      "matchUpdateTypes": ["major", "minor", "patch", "pin"],
+      "groupName": "Nix flake inputs",
+      "groupSlug": "nix-flake-inputs",
       "labels": ["dependencies", "nix"]
     },
     {
-      "description": "Group JavaScript dependency bumps across package workspaces to reduce Dependabot-style PR noise.",
+      "description": "Group non-major JavaScript workspace bumps.",
       "matchManagers": ["npm", "bun"],
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "groupName": "JavaScript package dependencies",
       "groupSlug": "javascript-package-dependencies",
-      "labels": ["dependencies", "javascript"]
-    },
-    {
-      "groupSlug": "low-risk-non-major",
-      "description": "Automerge low-risk non-major updates after the stability window and CI pass.",
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "labels": ["dependencies", "javascript"],
       "automerge": true,
       "automergeType": "branch"
     },
     {
-      "groupSlug": "manual-major",
-      "description": "Keep major updates visible for manual review.",
-      "matchUpdateTypes": ["major"],
-      "automerge": false
+      "description": "Group non-major GitHub Actions and pin/digest refreshes.",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "GitHub Actions",
+      "groupSlug": "github-actions",
+      "labels": ["dependencies", "github_actions"],
+      "automerge": true,
+      "automergeType": "branch"
     },
     {
-      "groupSlug": "nix-flake-inputs",
-      "description": "Group all remaining Nix flake input bumps to reduce PR noise.",
-      "matchManagers": ["nix"],
-      "groupName": "Nix flake inputs"
-    },
-    {
-      "groupSlug": "repo-local-nix-packages",
-      "description": "Group repo-local Nix package source bumps to reduce PR noise.",
+      "description": "Group only repo-local Nix package patches so hash refresh stays small enough to finish.",
       "matchManagers": ["custom.regex"],
-      "groupName": "repo-local Nix packages",
-      "labels": ["dependencies", "nix", "packages"]
+      "matchUpdateTypes": ["patch", "pin", "digest"],
+      "groupName": "repo-local Nix package patches",
+      "groupSlug": "repo-local-nix-package-patches",
+      "labels": ["dependencies", "nix", "packages"],
+      "automerge": true,
+      "automergeType": "branch"
     },
     {
       "description": "Let the patch-repair workflow validate Herdr before enabling platform automerge.",
@@ -148,18 +174,32 @@
       "groupSlug": "hunk",
       "labels": ["dependencies", "nix", "packages", "flue-review"],
       "automerge": false
+    },
+    {
+      "description": "Keep major updates on the Dependency Dashboard until explicitly approved.",
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true,
+      "automerge": false,
+      "labels": ["dependencies", "major"]
+    },
+    {
+      "description": "Automerge low-risk non-major updates after the stability window and CI pass. Do not set groupSlug here; that previously collapsed unrelated PRs onto renovate/low-risk-non-major.",
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true,
+      "automergeType": "branch"
     }
   ],
   "osvVulnerabilityAlerts": true,
   "dependencyDashboard": true,
-  "timezone": "America/Chicago",
   "prCreation": "not-pending",
   "internalChecksFilter": "strict",
   "minimumReleaseAge": "3 days",
-  "automerge": true,
+  "separateMajorMinor": true,
+  "separateMultipleMajor": true,
+  "automerge": false,
   "automergeType": "branch",
-  "platformAutomerge": true,
+  "platformAutomerge": false,
   "rebaseWhen": "conflicted",
   "prHourlyLimit": 2,
-  "prConcurrentLimit": 5
+  "prConcurrentLimit": 4
 }

--- a/renovate.json
+++ b/renovate.json
@@ -158,6 +158,19 @@
       "automergeType": "branch"
     },
     {
+      "description": "Keep major updates on the Dependency Dashboard until explicitly approved.",
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true,
+      "automerge": false,
+      "labels": ["dependencies", "major"]
+    },
+    {
+      "description": "Automerge low-risk non-major updates after the stability window and CI pass. Do not set groupSlug here; that previously collapsed unrelated PRs onto renovate/low-risk-non-major.",
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true,
+      "automergeType": "branch"
+    },
+    {
       "description": "Let the patch-repair workflow validate Herdr before enabling platform automerge.",
       "matchManagers": ["custom.regex"],
       "matchDepNames": ["herdr"],
@@ -174,19 +187,6 @@
       "groupSlug": "hunk",
       "labels": ["dependencies", "nix", "packages", "flue-review"],
       "automerge": false
-    },
-    {
-      "description": "Keep major updates on the Dependency Dashboard until explicitly approved.",
-      "matchUpdateTypes": ["major"],
-      "dependencyDashboardApproval": true,
-      "automerge": false,
-      "labels": ["dependencies", "major"]
-    },
-    {
-      "description": "Automerge low-risk non-major updates after the stability window and CI pass. Do not set groupSlug here; that previously collapsed unrelated PRs onto renovate/low-risk-non-major.",
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "automerge": true,
-      "automergeType": "branch"
     }
   ],
   "osvVulnerabilityAlerts": true,

--- a/tests/test_package_policy.py
+++ b/tests/test_package_policy.py
@@ -373,6 +373,76 @@ class PackagePolicyTest(unittest.TestCase):
             rejected.stderr,
         )
 
+    def test_renovate_config_keeps_hash_refresh_and_reduces_noise(self):
+        config = json.loads((ROOT / "renovate.json").read_text())
+        workflow = (ROOT / ".github/workflows/renovate.yml").read_text()
+        command = "nix run --accept-flake-config .#renovate-update-nix-hashes"
+
+        self.assertIn("config:recommended", config["extends"])
+        self.assertTrue(config["nix"]["enabled"])
+        self.assertTrue(config["dependencyDashboard"])
+        self.assertTrue(config["lockFileMaintenance"]["enabled"])
+        self.assertEqual(config["minimumReleaseAge"], "3 days")
+        self.assertEqual(config["prHourlyLimit"], 2)
+        self.assertLessEqual(config["prConcurrentLimit"], 5)
+        self.assertFalse(config["automerge"])
+        self.assertFalse(config["platformAutomerge"])
+        self.assertEqual(config["postUpgradeTasks"]["commands"], [command])
+        self.assertRegex(command, config["allowedCommands"][0])
+        self.assertIn("nix run --accept-flake-config", workflow)
+        self.assertIn("renovate-update-nix-hashes", workflow)
+        self.assertIn("accept-flake-config = true", workflow)
+        hash_script = (ROOT / "flake.nix").read_text()
+        self.assertIn("nix-update --flake --version=skip", hash_script)
+        self.assertNotIn("nix-update --flake --version=skip --build", hash_script)
+
+        descriptions = {manager["description"] for manager in config["customManagers"]}
+        self.assertGreaterEqual(len(config["customManagers"]), 5)
+        self.assertTrue(any("packages/" in description for description in descriptions))
+        self.assertTrue(any("Herdr overlay" in description for description in descriptions))
+        self.assertTrue(any("Hunk's flake input" in description for description in descriptions))
+
+        grouped_without_name = [
+            rule
+            for rule in config["packageRules"]
+            if "groupSlug" in rule and "groupName" not in rule
+        ]
+        self.assertEqual(
+            grouped_without_name,
+            [],
+            "groupSlug without groupName collapses unrelated PRs onto one branch",
+        )
+
+        herdr = next(rule for rule in config["packageRules"] if rule.get("groupSlug") == "herdr")
+        hunk = next(rule for rule in config["packageRules"] if rule.get("groupSlug") == "hunk")
+        self.assertFalse(herdr["automerge"])
+        self.assertFalse(hunk["automerge"])
+
+        digest_rule = next(
+            rule
+            for rule in config["packageRules"]
+            if rule.get("matchDatasources") == ["git-refs"]
+            and rule.get("matchUpdateTypes") == ["digest"]
+        )
+        self.assertFalse(digest_rule["enabled"])
+
+        nix_groups = [
+            rule
+            for rule in config["packageRules"]
+            if rule.get("matchManagers") == ["nix"] and "groupName" in rule
+        ]
+        self.assertTrue(nix_groups)
+        for rule in nix_groups:
+            self.assertNotIn(
+                "lockFileMaintenance",
+                rule.get("matchUpdateTypes", []),
+                "lockFileMaintenance must stay off grouped flake-input PRs",
+            )
+
+        majors = next(rule for rule in config["packageRules"] if rule.get("matchUpdateTypes") == ["major"])
+        self.assertTrue(majors["dependencyDashboardApproval"])
+        self.assertFalse(majors["automerge"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_package_policy.py
+++ b/tests/test_package_policy.py
@@ -413,8 +413,12 @@ class PackagePolicyTest(unittest.TestCase):
             "groupSlug without groupName collapses unrelated PRs onto one branch",
         )
 
+        slugs = [rule.get("groupSlug") for rule in config["packageRules"]]
+        self.assertLess(slugs.index("javascript-package-dependencies"), slugs.index("herdr"))
         herdr = next(rule for rule in config["packageRules"] if rule.get("groupSlug") == "herdr")
         hunk = next(rule for rule in config["packageRules"] if rule.get("groupSlug") == "hunk")
+        self.assertEqual(config["packageRules"][-2]["groupSlug"], "herdr")
+        self.assertEqual(config["packageRules"][-1]["groupSlug"], "hunk")
         self.assertFalse(herdr["automerge"])
         self.assertFalse(hunk["automerge"])
 

--- a/tests/test_package_policy.py
+++ b/tests/test_package_policy.py
@@ -373,6 +373,17 @@ class PackagePolicyTest(unittest.TestCase):
             rejected.stderr,
         )
 
+    def test_herdr_vm_test_does_not_evaluate_private_tnote(self):
+        herdr_module = (ROOT / "modules/shell/herdr/default.nix").read_text()
+        vm_test = (ROOT / "modules/shell/herdr/_tests/vm-test.nix").read_text()
+        self.assertIn("tnote.enable = mkBoolOpt true;", herdr_module)
+        self.assertIn('optional cfg.tnote.enable "${pkgs.my.tnote}/bin"', herdr_module)
+        self.assertIn(
+            "herdrPackages ++ optional cfg.tnote.enable pkgs.my.tnote",
+            herdr_module,
+        )
+        self.assertIn("modules.shell.herdr.tnote.enable = false;", vm_test)
+
     def test_renovate_config_keeps_hash_refresh_and_reduces_noise(self):
         config = json.loads((ROOT / "renovate.json").read_text())
         workflow = (ROOT / ".github/workflows/renovate.yml").read_text()

--- a/tests/test_package_policy.py
+++ b/tests/test_package_policy.py
@@ -123,14 +123,25 @@ class PackagePolicyTest(unittest.TestCase):
                 script,
                 "packages/stack/patches/fix.patch",
                 "overlays/hunk/patches/fix.patch",
+                "skills/overlays/skill-doctor/pi-support.patch",
             ],
             capture_output=True,
             text=True,
         )
         self.assertEqual(allowed.returncode, 0, allowed.stderr)
+        locality_message = (
+            "Patch must live at packages/<name>/patches/*.patch, "
+            "overlays/<name>/patches/*.patch, or skills/overlays/<name>/*.patch"
+        )
         invalid_cases = [
             (["patches/fix.patch"], "patches/fix.patch"),
             (["misc/fix.patch"], "misc/fix.patch"),
+            (["skills/fix.patch"], "skills/fix.patch"),
+            (["skills/overlays/fix.patch"], "skills/overlays/fix.patch"),
+            (
+                ["skills/overlays/skill-doctor/nested/fix.patch"],
+                "skills/overlays/skill-doctor/nested/fix.patch",
+            ),
             (["packages/group/tool/patches/fix.patch"], "packages/group/tool/patches/fix.patch"),
             (
                 [
@@ -145,10 +156,7 @@ class PackagePolicyTest(unittest.TestCase):
             with self.subTest(paths=paths):
                 rejected = subprocess.run(["bash", script, *paths], capture_output=True, text=True)
                 self.assertEqual(rejected.returncode, 1)
-                self.assertIn(
-                    "Patch must live at packages/<name>/patches/*.patch or overlays/<name>/patches/*.patch",
-                    rejected.stderr,
-                )
+                self.assertIn(locality_message, rejected.stderr)
                 self.assertIn(offending_path, rejected.stderr)
 
     def test_renovate_patch_repair_uses_trusted_agent_shell(self):

--- a/tests/test_package_policy.py
+++ b/tests/test_package_policy.py
@@ -373,6 +373,11 @@ class PackagePolicyTest(unittest.TestCase):
             rejected.stderr,
         )
 
+    def test_herdr_config_template_uses_supported_sound_format(self):
+        template = (ROOT / "config/herdr/config.toml").read_text()
+        self.assertNotIn("done_path", template)
+        self.assertIn("[ui.sound]", template)
+
     def test_herdr_vm_test_does_not_evaluate_private_tnote(self):
         herdr_module = (ROOT / "modules/shell/herdr/default.nix").read_text()
         vm_test = (ROOT / "modules/shell/herdr/_tests/vm-test.nix").read_text()

--- a/tests/test_rift_herdr_runtime.py
+++ b/tests/test_rift_herdr_runtime.py
@@ -13,3 +13,13 @@ def test_rift_is_packaged_only_for_herdr_agent_runtime() -> None:
     assert '"${pkgs.my.rift}/bin"' in herdr_module
     assert 'home.file.".local/bin/rift".source = lib.getExe pkgs.my.rift;' in herdr_module
     assert "pkgs.my.rift" not in (ROOT / "default.nix").read_text()
+
+
+def test_herdr_vm_test_does_not_evaluate_private_tnote() -> None:
+    herdr_module = (ROOT / "modules" / "shell" / "herdr" / "default.nix").read_text()
+    vm_test = (ROOT / "modules" / "shell" / "herdr" / "_tests" / "vm-test.nix").read_text()
+
+    assert "tnote.enable = mkBoolOpt true;" in herdr_module
+    assert 'optional cfg.tnote.enable "${pkgs.my.tnote}/bin"' in herdr_module
+    assert "herdrPackages ++ optional cfg.tnote.enable pkgs.my.tnote" in herdr_module
+    assert "modules.shell.herdr.tnote.enable = false;" in vm_test


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Renovate **is** running, but it was easy to miss and it was failing every day.

This repo self-hosts Renovate via `.github/workflows/renovate.yml` with `RENOVATE_TOKEN`. It does **not** use the Mend GitHub App. PRs and the Dependency Dashboard are authored as the PAT owner (`edmundmiller`), so `author:app/renovate` shows nothing.

The scheduled Action has failed on every recent run. The live [Dependency Dashboard](https://github.com/edmundmiller/dotfiles/issues/186) already listed:

- `lookupUpdates error` for private flake inputs (`agents-workspace`, `tnote`) the PAT cannot `ls-remote`
- two lock-file maintenance rows (`renovate/lock-file-maintenance` **and** `renovate/lock-file-maintenance-nix-flake-inputs`) because the Nix group swallowed `lockFileMaintenance`
- a 14-package regex mega-PR ([#213](https://github.com/edmundmiller/dotfiles/pull/213)) whose `postUpgradeTasks` hash refresh failed (`renovate/artifacts`), so versions moved and hashes stayed stale
- JavaScript bumps on branch `renovate/low-risk-non-major` ([#214](https://github.com/edmundmiller/dotfiles/pull/214)) because an automerge rule set `groupSlug` without `groupName`

Noise-reduction settings from https://docs.renovatebot.com/noise-reduction/ that fit a personal Nix dotfiles repo: Dependency Dashboard (already on), weekday-morning schedule aligned with the Action, grouping by manager, branch automerge for safe non-majors, `minimumReleaseAge: 3 days`, majors behind dashboard approval, and no digest-PR + lockFileMaintenance double spam.

Custom regex managers and the Nix hash-refresh command stay. The command now accepts flake config, skips non-exported package attrs, and updates hashes with `nix-update --version=skip` instead of `--build`. Herdr/Hunk packageRules stay last so the generic automerge rule cannot override them.

## CI fixes on this PR

These were red on this PR **and** on recent `main`. Rebase was not an option: this branch is already based on latest `main` (`8eab83e1`), and latest main CI (`34012755367`) failed the same Herdr VM + Checks jobs.

1. **Herdr VM Test** — `modules.shell.herdr` interpolated private `pkgs.my.tnote` into `open-herdr.sh`, and CI got HTTP 404 fetching `edmundmiller/tnote`. tnote is now behind `modules.shell.herdr.tnote.enable` (default true). The config-check VM disables it; `herdr config check` assertions are unchanged.
2. **herdr-config-check** — the template set `ui.sound.done_path` to a macOS `.aiff`. Linux activation already strips `[ui.sound]`, so the VM passed after the tnote fix while the raw template check failed. Dropped the unused `done_path` (`enabled = false` already).
3. **pre-commit / Checks (Linux)** — `forbid-misplaced-patches` rejected the documented `skills/overlays/<name>/*.patch` layout (`skills/AGENTS.md`). The hook now allows that path and still rejects stray `.patch` files. Also applied the treefmt diffs Checks already flagged (renovate runbook table + meshify markdown/json already on main).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Chore / refactor
- [x] Documentation
- [x] CI / infrastructure

## Area Affected

Renovate config, self-hosted Action, `renovate-update-nix-hashes`, Herdr module eval isolation, patch-locality hook, docs/runbooks

## How to verify

1. After merge, run **Actions → Renovate → Run workflow** (or wait for `17 10 * * *`).
2. Dashboard issue should refresh without private-input `lookupUpdates` errors.
3. Old branches `renovate/repo-local-nix-packages` and `renovate/low-risk-non-major` should autoclose; new PRs should match the table in `docs/runbooks/renovate.md`.
4. A repo-local Nix package PR must rewrite source hashes in the same commit. If `renovate/artifacts` fails, do not merge.
5. Force retry: dashboard rebase/unlimit checkboxes, or `workflow_dispatch`.
6. `CI / Herdr VM Test (Linux)` and `CI / Checks (Linux)` should pass on this HEAD (both fail on current `main`).

Live checks: `gh issue list --search 'Dependency Dashboard in:title'` and `gh run list --workflow=renovate.yml --limit 5`.

## Testing Done

- [x] `python3 -m unittest tests.test_package_policy -v`
- [x] Herdr tnote isolation contract
- [ ] `hey check --worktree` — this cloud checkout has no Nix
- [ ] Tested `darwin-rebuild switch --flake .` on macOS

## Checklist

- [ ] Ran `hey check` with no errors
- [ ] Tested a full system rebuild
- [ ] Nix evaluation succeeds (`nix flake check`)
- [x] No secrets or sensitive data committed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6489547b-1069-4700-aee6-e2bdcecba8f9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6489547b-1069-4700-aee6-e2bdcecba8f9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

