### PR TITLE
feat(dji-mic): map Mini receiver button to Raycast dictation

### DIFF
--- a/bin/hey.d/flake.nu
+++ b/bin/hey.d/flake.nu
@@ -251,7 +251,7 @@ def "main check" [
     print ""
     print "==> Running DJI Mic Mini checks..."
     let dji_mic_check = (with-env { NIX_CONFIG: $authenticated_nix_config } {
-      ^nix build $".#checks.($ctx.nix_system).dji-mic-mini-receiver-mute-regressions" $".#checks.($ctx.nix_system).dji-mic-mini-platform-boundaries" --no-link | complete
+      ^nix build $".#checks.($ctx.nix_system).dji-mic-mini-receiver-mute-regressions" $".#checks.($ctx.nix_system).dji-mic-mini-platform-boundaries" $".#checks.($ctx.nix_system).dji-mic-raycast-dictation-regressions" --no-link | complete
     })
     if $dji_mic_check.exit_code == 0 {
       print "✓ DJI Mic Mini checks OK"

--- a/config/karabiner/dji-mic-raycast-dictation.json
+++ b/config/karabiner/dji-mic-raycast-dictation.json
@@ -1,0 +1,41 @@
+{
+  "title": "DJI Mic Mini receiver → Raycast dictation",
+  "rules": [
+    {
+      "description": "DJI Mic Mini receiver button toggles Raycast dictation (Ctrl+Option+Command+Space)",
+      "manipulators": [
+        {
+          "type": "basic",
+          "from": {
+            "consumer_key_code": "volume_increment",
+            "modifiers": { "optional": ["any"] }
+          },
+          "to": [
+            {
+              "key_code": "spacebar",
+              "modifiers": [
+                "left_control",
+                "left_option",
+                "left_command"
+              ],
+              "hold_down_milliseconds": 120,
+              "repeat": false
+            }
+          ],
+          "conditions": [
+            {
+              "type": "device_if",
+              "identifiers": [
+                {
+                  "vendor_id": 11427,
+                  "product_id": 16401,
+                  "is_consumer": true
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,11 @@ update_when: A canonical doc is added, moved, or changes ownership.
 - [tmux/managing-agents.md](./tmux/managing-agents.md) — user-first tmux agent
   launch model and architecture layering
 
+### Desktop / Darwin
+
+- [dji-mic-raycast-dictation.md](./dji-mic-raycast-dictation.md) — DJI Mic Mini
+  mobile-receiver button → Raycast dictation (Karabiner VirtualHID chord)
+
 ### Runbooks
 
 - [runbooks/README.md](./runbooks/README.md) — operational runbook index

--- a/docs/dji-mic-raycast-dictation.md
+++ b/docs/dji-mic-raycast-dictation.md
@@ -1,0 +1,86 @@
+---
+purpose: Enable the DJI Mic Mini mobile-receiver link button as Raycast dictation start/end.
+applies_to: Darwin hosts with the USB mobile receiver and Raycast dictation.
+entrypoint: modules.desktop.apps.djiMicMiniRaycastDictation.enable
+verification: hey check --worktree; then a live receiver button press starts/stops Raycast dictation.
+update_when: The receiver HID IDs, Raycast chord, or remapper (Karabiner vs hidutil/Kanata) change.
+---
+
+# DJI Mic Mini → Raycast dictation
+
+Pressing the transmitter link button makes the **mobile USB receiver** emit HID
+Consumer Control `0x0C/0xE9` (volume increment). Remap that usage **only** from
+the DJI receiver so keyboard volume keys stay untouched. The physical button
+then toggles Raycast dictation.
+
+## Hardware assumption
+
+- DJI Mic Mini (or Mini 2) **mobile receiver** plugged in over USB-C
+- Receiver USB IDs: vendor `11427` (`0x2CA3`), product `16401` (`0x4011`)
+- Bluetooth-only mode exposes audio, not the button HID event
+
+This is the same device already used by
+`modules.desktop.apps.djiMicMiniReceiverMute`. The two features share the
+button and are mutually exclusive.
+
+## How to enable
+
+1. On the Darwin host (MacTraitor-Pro already does this):
+
+   ```nix
+   modules.desktop.apps.raycast.enable = true;
+   modules.desktop.apps.djiMicMiniRaycastDictation.enable = true;
+   modules.desktop.apps.djiMicMiniReceiverMute.enable = false;
+   ```
+
+2. Rebuild with authorized `hey re`. The module only installs
+   `~/.config/karabiner/assets/complex_modifications/dji-mic-raycast-dictation.json`.
+3. In Karabiner-Elements → Complex Modifications, enable **DJI Mic Mini
+   receiver → Raycast dictation** and disable the receiver-mute rule if it is
+   still on.
+4. In Raycast, bind **Dictation** to **Ctrl+Option+Command+Space**. That
+   binding lives in Raycast's encrypted SQLite and is not Nix-managed.
+
+Karabiner-Elements itself is not installed by this module (same pattern as the
+mute asset). Grant it Input Monitoring and Accessibility if macOS prompts.
+
+## Why Karabiner instead of Bedesqui's Kanata helper
+
+Igor Bedesqui's working stack in [bdsqqq/dots](https://github.com/bdsqqq/dots):
+
+| Commit | What it established |
+| --- | --- |
+| [`defaf70`](https://github.com/bdsqqq/dots/commit/defaf703436b4f17170a489c9bb4dc87583f3c9a) | Persist a receiver-only hidutil remap |
+| [`0a3a23f`](https://github.com/bdsqqq/dots/commit/0a3a23faf603e3e95c17aadd49ead5129f4af386) | Translate the event toward a Raycast chord |
+| [`6ea0e96`](https://github.com/bdsqqq/dots/commit/6ea0e9695e9f3d2d445f3e68e30f7008da1793d7) | Route the chord through virtual HID (`C-A-M-spc`) because event-tap rewrites and `CGEventPost` arrive too late for Raycast |
+| [`b3a3190`](https://github.com/bdsqqq/dots/commit/b3a319068bcd4230f5f0ae543bb2a38c7ebf6e73) | Hold the chord 120 ms; Kanata's zero-duration Tap was too short |
+| [`273ced1`](https://github.com/bdsqqq/dots/commit/273ced171d9263ed537eb89f172aa60feade423c) | Sign the helper to a stable path so Accessibility TCC survives rebuilds |
+
+Public write-up: [the button works](https://x.com/bedesqui/status/2098541184272544225),
+[commits as source of truth](https://x.com/bedesqui/status/2098781296113697105).
+
+This repo already owns that receiver event in Karabiner and already manages
+Raycast prefs. Porting Kanata, its VirtualHID LaunchDaemon, an unauthenticated
+TCP control port, and a personal Apple Development signing identity would add a
+second keyboard stack. Karabiner's VirtualHIDDevice emits the same
+`C-A-M-spc` chord for 120 ms, scoped to vendor/product/consumer.
+
+## Blocked / manual pieces
+
+- **Raycast dictation hotkey** — encrypted SQLite; set `⌃⌥⌘Space` once
+- **Kanata + signed `dji-mic-hid-remap`** — not ported; no signing identity in
+  this flake, and Kanata would fight the existing Karabiner path
+- **Host activation** — configuration only; `hey re` still needs authorization
+- **Accessibility** — required for Karabiner (already). The Bedesqui helper's
+  extra Accessibility grant is unnecessary on this path
+
+## How to verify
+
+1. Plug in the mobile receiver. `system_profiler SPUSBDataType` should show DJI
+   vendor `0x2ca3` / product `0x4011`.
+2. Confirm Karabiner lists the receiver-scoped rule and that mute is off.
+3. Confirm Raycast Dictation is `⌃⌥⌘Space`.
+4. Press the transmitter link button once: Raycast dictation starts. Press
+   again: it ends. Laptop volume keys must still change volume.
+5. `hey check --worktree` covers the rule JSON and MacTraitor-Pro wiring.
+   Live button behavior needs the receiver on a Mac.

--- a/flake.nix
+++ b/flake.nix
@@ -1521,6 +1521,11 @@
                 inherit pkgs;
               };
 
+              dji-mic-raycast-dictation-regressions = import ./hosts/mactraitorpro/_tests/dji-mic-raycast-dictation.nix {
+                darwinConfig = self.darwinConfigurations."MacTraitor-Pro";
+                inherit pkgs;
+              };
+
               screentime-backup-darwin-assertions = import ./hosts/mactraitorpro/_tests/screentime-backup.nix {
                 darwinConfig = self.darwinConfigurations."MacTraitor-Pro";
                 inherit pkgs;
@@ -1646,7 +1651,8 @@
                   heyCheckSource = builtins.readFile ./bin/hey.d/flake.nu;
                   heyCheckSelectsDjiChecks =
                     lib.hasInfix "dji-mic-mini-receiver-mute-regressions" heyCheckSource
-                    && lib.hasInfix "dji-mic-mini-platform-boundaries" heyCheckSource;
+                    && lib.hasInfix "dji-mic-mini-platform-boundaries" heyCheckSource
+                    && lib.hasInfix "dji-mic-raycast-dictation-regressions" heyCheckSource;
                   boundariesHold =
                     !(builtins.hasAttr "dji-mic-mini-receiver-mute" self.packages.${linuxSystem})
                     && !(builtins.hasAttr "dji-mic-mini-receiver-mute-regressions" self.checks.${linuxSystem})

--- a/hosts/mactraitorpro/README.md
+++ b/hosts/mactraitorpro/README.md
@@ -10,6 +10,12 @@ update_when: Host hardware, cabling, or a verified recovery procedure changes.
 
 Human-facing setup and troubleshooting for the personal Mac.
 
+## DJI Mic Mini
+
+The mobile USB receiver's link button is wired to Raycast dictation on this
+host. Setup, Karabiner enablement, and the manual Raycast hotkey are in
+[dji-mic-raycast-dictation.md](../../docs/dji-mic-raycast-dictation.md).
+
 ## Workload placement
 
 - [Amp Orb, Mac, NUC, and Meshify routing](workload-placement.md) — keeps

--- a/hosts/mactraitorpro/_tests/dji-mic-raycast-dictation.nix
+++ b/hosts/mactraitorpro/_tests/dji-mic-raycast-dictation.nix
@@ -1,0 +1,83 @@
+# Pure Nix/build test: MacTraitor-Pro wires DJI receiver button → Raycast chord.
+{
+  darwinConfig,
+  pkgs,
+}:
+let
+  inherit (builtins) filter length;
+  inherit (pkgs.lib.strings) hasInfix;
+
+  mac = darwinConfig.config;
+  rule = builtins.fromJSON (
+    builtins.readFile ../../../config/karabiner/dji-mic-raycast-dictation.json
+  );
+  manipulator = builtins.elemAt (builtins.elemAt rule.rules 0).manipulators 0;
+  toEvent = builtins.elemAt manipulator.to 0;
+  identifier = builtins.elemAt (builtins.elemAt manipulator.conditions 0).identifiers 0;
+  dictationAsset = ".config/karabiner/assets/complex_modifications/dji-mic-raycast-dictation.json";
+  muteAsset = ".config/karabiner/assets/complex_modifications/dji-mic-mini-receiver-mute.json";
+  installedSource = mac.home.file.${dictationAsset}.source or "";
+
+  assertions = [
+    {
+      test = mac.modules.desktop.apps.djiMicMiniRaycastDictation.enable;
+      msg = "MacTraitor-Pro must enable DJI Mic Mini Raycast dictation";
+    }
+    {
+      test = !mac.modules.desktop.apps.djiMicMiniReceiverMute.enable;
+      msg = "MacTraitor-Pro must not also enable the receiver-mute mapping on the same button";
+    }
+    {
+      test = mac.modules.desktop.apps.raycast.enable;
+      msg = "Raycast must stay enabled so dictation is the installed launcher";
+    }
+    {
+      test = hasInfix "dji-mic-raycast-dictation.json" (toString installedSource);
+      msg = "Home Manager must install the receiver-scoped Karabiner dictation asset";
+    }
+    {
+      test = !(mac.home.file ? ${muteAsset});
+      msg = "the mute Karabiner asset must not be installed while dictation owns the button";
+    }
+    {
+      test = manipulator.from.consumer_key_code == "volume_increment";
+      msg = "the rule must match Consumer Control volume increment (0x0C/0xE9)";
+    }
+    {
+      test = identifier.vendor_id == 11427 && identifier.product_id == 16401 && identifier.is_consumer;
+      msg = "the rule must match only the DJI mobile receiver consumer interface";
+    }
+    {
+      test = toEvent.key_code == "spacebar";
+      msg = "the emitted chord must include Space";
+    }
+    {
+      test = toEvent.modifiers == [
+        "left_control"
+        "left_option"
+        "left_command"
+      ];
+      msg = "the emitted chord must be Ctrl+Option+Command (Bedesqui C-A-M-spc)";
+    }
+    {
+      test = toEvent.hold_down_milliseconds == 120 && toEvent.repeat == false;
+      msg = "the chord must be held 120 ms without key repeat";
+    }
+  ];
+
+  failures = filter (assertion: !assertion.test) assertions;
+in
+pkgs.runCommand "dji-mic-raycast-dictation-regressions"
+  {
+    passthru = {
+      inherit assertions failures;
+    };
+  }
+  ''
+    if [ ${toString (length failures)} -ne 0 ]; then
+      echo "${toString (length failures)} DJI Mic Mini Raycast dictation assertions failed" >&2
+      exit 1
+    fi
+    mkdir -p "$out"
+    echo "DJI Mic Mini Raycast dictation wiring OK." > "$out/result"
+  ''

--- a/hosts/mactraitorpro/_tests/dji-mic-raycast-dictation.nix
+++ b/hosts/mactraitorpro/_tests/dji-mic-raycast-dictation.nix
@@ -16,7 +16,8 @@ let
   identifier = builtins.elemAt (builtins.elemAt manipulator.conditions 0).identifiers 0;
   dictationAsset = ".config/karabiner/assets/complex_modifications/dji-mic-raycast-dictation.json";
   muteAsset = ".config/karabiner/assets/complex_modifications/dji-mic-mini-receiver-mute.json";
-  installedSource = mac.home.file.${dictationAsset}.source or "";
+  homeFiles = mac.home-manager.users.${mac.user.name}.home.file;
+  installedSource = homeFiles.${dictationAsset}.source or "";
 
   assertions = [
     {
@@ -36,7 +37,7 @@ let
       msg = "Home Manager must install the receiver-scoped Karabiner dictation asset";
     }
     {
-      test = !(mac.home.file ? ${muteAsset});
+      test = !(homeFiles ? ${muteAsset});
       msg = "the mute Karabiner asset must not be installed while dictation owns the button";
     }
     {

--- a/hosts/mactraitorpro/default.nix
+++ b/hosts/mactraitorpro/default.nix
@@ -288,7 +288,8 @@ in
       desktop = {
         apps.raycast.enable = true;
         apps.audioPriorityBar.enable = true;
-        apps.djiMicMiniReceiverMute.enable = true;
+        apps.djiMicMiniRaycastDictation.enable = true;
+        apps.djiMicMiniReceiverMute.enable = false;
         apps.handy.enable = true;
         apps.neovide.enable = true;
         term = {

--- a/modules/desktop/apps/dji-mic-mini-receiver-mute.nix
+++ b/modules/desktop/apps/dji-mic-mini-receiver-mute.nix
@@ -16,6 +16,13 @@ in
 
   config = optionalAttrs isDarwin (
     mkIf cfg.enable {
+      assertions = [
+        {
+          assertion = !config.modules.desktop.apps.djiMicMiniRaycastDictation.enable;
+          message = "DJI Mic Mini receiver button cannot both mute and trigger Raycast dictation";
+        }
+      ];
+
       home.file.".local/bin/dji-mic-mini-receiver-mute".source =
         lib.getExe pkgs.my.dji-mic-mini-receiver-mute;
 

--- a/modules/desktop/apps/dji-mic-raycast-dictation.nix
+++ b/modules/desktop/apps/dji-mic-raycast-dictation.nix
@@ -1,0 +1,36 @@
+# DJI Mic Mini (mobile receiver) link button → Raycast dictation.
+#
+# Bedesqui's working path (bdsqqq/dots) is hidutil → F18 → Kanata virtual HID
+# emitting Ctrl+Option+Command+Space for 120 ms. This repo already remaps the
+# same receiver-scoped Consumer Control 0x0C/0xE9 through Karabiner's
+# VirtualHIDDevice, so the Nix-managed piece is that chord — not a second
+# Kanata stack. Raycast's dictation hotkey stays manual (encrypted SQLite).
+{
+  config,
+  lib,
+  isDarwin,
+  ...
+}:
+with lib;
+with lib.my;
+let
+  cfg = config.modules.desktop.apps.djiMicMiniRaycastDictation;
+  ruleSource = "${config.dotfiles.configDir}/karabiner/dji-mic-raycast-dictation.json";
+in
+{
+  options.modules.desktop.apps.djiMicMiniRaycastDictation.enable = mkBoolOpt false;
+
+  config = optionalAttrs isDarwin (
+    mkIf cfg.enable {
+      assertions = [
+        {
+          assertion = !config.modules.desktop.apps.djiMicMiniReceiverMute.enable;
+          message = "DJI Mic Mini receiver button cannot both mute and trigger Raycast dictation";
+        }
+      ];
+
+      home.file.".config/karabiner/assets/complex_modifications/dji-mic-raycast-dictation.json".source =
+        ruleSource;
+    }
+  );
+}

--- a/modules/desktop/apps/raycast.nix
+++ b/modules/desktop/apps/raycast.nix
@@ -10,7 +10,9 @@
 #
 # NOT managed (Raycast stores these in encrypted SQLite):
 #   - Extension installs/configs
-#   - Extension hotkey bindings
+#   - Extension hotkey bindings, including Dictation (Ctrl+Option+Command+Space
+#     when using modules.desktop.apps.djiMicMiniRaycastDictation; see
+#     docs/dji-mic-raycast-dictation.md)
 #   - Cloud sync settings
 #   - Raycast Beta installation (no Homebrew cask currently; keep /Applications/Raycast Beta.app installed manually)
 #


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Port Igor Bedesqui’s DJI Mic Mini (mobile receiver) link-button → Raycast dictation start/end onto this flake.

## Why this shape

Bedesqui’s published thread and the commits he pointed agents at are the source of truth:

- [I DID IT — physical button starts/ends Raycast dictation](https://x.com/bedesqui/status/2098541184272544225): the mobile receiver emits USB HID Consumer Control `0x0C/0xE9`; remap that usage **only** when it comes from the receiver.
- [Ask your agent to dig through yesterday’s commits](https://x.com/bedesqui/status/2098781296113697105) in [bdsqqq/dots](https://github.com/bdsqqq/dots).

What those commits actually settled on:

| Commit | Decision |
| --- | --- |
| [`defaf70`](https://github.com/bdsqqq/dots/commit/defaf703436b4f17170a489c9bb4dc87583f3c9a) | Persist a receiver-only hidutil remap (vendor `11427` / product `16401`). |
| [`0a3a23f`](https://github.com/bdsqqq/dots/commit/0a3a23faf603e3e95c17aadd49ead5129f4af386) | Translate the event toward a Raycast chord (ended as F18 sentinel → `⌃⌥⌘Space`). |
| [`6ea0e96`](https://github.com/bdsqqq/dots/commit/6ea0e9695e9f3d2d445f3e68e30f7008da1793d7) | Route the chord through **virtual HID**. Event-tap rewrites and `CGEventPost` arrive too late for Raycast; Kanata’s virtual keyboard enters before global-hotkey dispatch. Virtual key: `dji-dictation` → `C-A-M-spc`. |
| [`b3a3190`](https://github.com/bdsqqq/dots/commit/b3a319068bcd4230f5f0ae543bb2a38c7ebf6e73) | Hold the chord **120 ms**. Kanata’s zero-duration `Tap` produced incomplete modifier combinations. |
| [`273ced1`](https://github.com/bdsqqq/dots/commit/273ced171d9263ed537eb89f172aa60feade423c) | Install the helper at a stable path and sign it with a personal Apple Development identity so Accessibility TCC survives Nix rebuilds. |

This repo already remaps that exact receiver event through Karabiner (`dji-mic-mini-receiver-mute`) and already manages Raycast prefs — not extension/hotkey SQLite. It does **not** run Kanata. Adding Bedesqui’s Kanata LaunchDaemon, unauthenticated TCP `:5829`, Karabiner-VirtualHID system daemon (a second copy), and a personal signing identity would fight the existing remapper.

The smallest faithful port: Karabiner’s VirtualHIDDevice emits the same `⌃⌥⌘Space` chord for 120 ms, still scoped to the DJI consumer interface. Same button, same chord, same hold; different virtual-HID owner.

## What landed

- New Darwin module `modules.desktop.apps.djiMicMiniRaycastDictation`
- Karabiner asset matching vendor `11427`, product `16401`, `is_consumer`, `volume_increment` → `spacebar` + `left_control`/`left_option`/`left_command`, `hold_down_milliseconds: 120`
- MacTraitor-Pro enables dictation and turns the mute mapping off (same physical button)
- Mutual-exclusion assertions so both mappings cannot evaluate together
- Docs: hardware assumption, enablement, Accessibility, verification, blocked pieces
- Eval check that the host wiring and rule JSON stay aligned

Raycast remains the managed launcher. This does not add Kanata, hidutil launchd, or a Homebrew Karabiner cask.

## Blocked / manual

- **Raycast Dictation hotkey** lives in encrypted SQLite (already documented as unmanaged). Set it once to `⌃⌥⌘Space`.
- **Bedesqui’s signed `dji-mic-hid-remap` + Kanata TCP** are not ported: no Apple Development identity in this flake, and Kanata is not a host remapper here.
- **Karabiner-Elements** is still a pre-existing manual install (same as mute). After `hey re`, enable the new complex modification and disable the mute rule in the UI.
- **Activation** is not implied. Live button proof needs the receiver on the Mac.

## CI on HEAD (`67f7b5e7`)

Not merge blockers for this PR. Both red jobs reproduce on current `main` (`934b5504`, [run 34624029491](https://github.com/edmundmiller/dotfiles/actions/runs/34624029491)):

| Check | Result | Notes |
| --- | --- | --- |
| CI / Checks (Linux) | red | `herdr-config-check`: `ui.sound.done_path = /System/Library/Sounds/Submarine.aiff` (Herdr wants mp3). Same drv as `main`. This PR does not touch Herdr config. |
| CI / Herdr VM Test (Linux) | red | Cannot fetch private `edmundmiller/tnote` tarball (`HTTP 404`) while evaluating `tmux/open-herdr.sh`. Pre-existing infra. |
| Security / Secret Scanning | green | |
| Security / Nix Static Analysis | green | |
| PR Review Bot / review | green | |
| CI / Darwin-only checks | skipped | |
| CI / Service VM Tests (Linux) | skipped | |
| Renovate patch repair | skipped | |

`flake.nix` on this branch only adds the DJI dictation eval check and standard-gate infix. Do not merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-858dde9a-bee2-49cf-b8bb-e7947492ac2a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-858dde9a-bee2-49cf-b8bb-e7947492ac2a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

